### PR TITLE
Comments out memory error causing test function and printing out of tokens

### DIFF
--- a/sources/Config/ConfigParser.cpp
+++ b/sources/Config/ConfigParser.cpp
@@ -6,57 +6,57 @@
 
 void	testPrintConfigs(std::map<std::string, Config> configs)
 {
-    for (const auto &config : configs)
-    {
-        std::cout << "Host: " << config.second._host << "\n"; 
-        std::cout << "Names: ";
-        for (const auto& name : config.second._names)
-            std::cout << name << " ";
-        std::cout << "\n";
-        
-        std::cout << "Ports: ";
-        for (const auto& port : config.second._ports)
-            std::cout << port << " ";
-        std::cout << "\n";
-        
-        std::cout << "Number of Ports: " << config.second._num_of_ports << "\n";
-        std::cout << "Client Max Body Size: " << config.second._cli_max_bodysize << "\n";
-        
-        std::cout << "Default Pages:\n";
-        for (const auto& page : config.second._default_pages)
-            std::cout << "  " << page.first << ": " << page.second << "\n";
-        
-        std::cout << "Error Pages:\n";
-        for (const auto& page : config.second._error_pages)
-            //std::cout << "  " << page.first << ": " << page.second << "\n";
+	for (const auto &config : configs)
+	{
+		std::cout << "Host: " << config.second._host << "\n"; 
+		std::cout << "Names: ";
+		for (const auto& name : config.second._names)
+			std::cout << name << " ";
+		std::cout << "\n";
+		
+		std::cout << "Ports: ";
+		for (const auto& port : config.second._ports)
+			std::cout << port << " ";
+		std::cout << "\n";
+		
+		std::cout << "Number of Ports: " << config.second._num_of_ports << "\n";
+		std::cout << "Client Max Body Size: " << config.second._cli_max_bodysize << "\n";
+		
+		std::cout << "Default Pages:\n";
+		for (const auto& page : config.second._default_pages)
+			std::cout << "  " << page.first << ": " << page.second << "\n";
+		
+		std::cout << "Error Pages:\n";
+		for (const auto& page : config.second._error_pages)
+			//std::cout << "  " << page.first << ": " << page.second << "\n";
 			std::cout << page << " ";
-        
-        std::cout << "Error Codes:\n";
-        for (const auto& code : config.second._error_codes)
-            std::cout << "  " << code.first << ": " << code.second << "\n";
-        
-        std::cout << "CGI Params:\n";
-        for (const auto& param : config.second._cgi_params)
-            std::cout << "  " << param.first << " = " << param.second << "\n";
-        std::cout << "---------------------\n";
-        std::cout << "Locations:\n";
-        for (const auto& loc : config.second._location) {
-            const Location& location = loc.second;
-            std::cout << "  Path: " << location._path << "\n";
-            std::cout << "  Root: " << location._root << "\n";
-            std::cout << "  Index: " << location._index << "\n";
-            std::cout << "  CGI Path: " << location._cgi_path << "\n";
-            std::cout << "  CGI Param: " << location._cgi_param << "\n";
-            std::cout << "  Redirect: " << location._redirect.first << " -> " << location._redirect.second << "\n";
-            std::cout << "  Directory Listing: " << (location._dir_listing ? "Enabled" : "Disabled") << "\n";
-            
-            std::cout << "  Methods:\n";
-            for (const auto& method : location._methods)
-                std::cout << "    " << method.first << ": " << (method.second ? "Allowed" : "Not Allowed") << "\n";
-            
-            std::cout << "\n";
-        }
-    }
+		
+		std::cout << "Error Codes:\n";
+		for (const auto& code : config.second._error_codes)
+			std::cout << "  " << code.first << ": " << code.second << "\n";
+		
+		std::cout << "CGI Params:\n";
+		for (const auto& param : config.second._cgi_params)
+			std::cout << "  " << param.first << " = " << param.second << "\n";
+		std::cout << "---------------------\n";
+		std::cout << "Locations:\n";
+		for (const auto& loc : config.second._location) {
+			const Location& location = loc.second;
+			std::cout << "  Path: " << location._path << "\n";
+			std::cout << "  Root: " << location._root << "\n";
+			std::cout << "  Index: " << location._index << "\n";
+			std::cout << "  CGI Path: " << location._cgi_path << "\n";
+			std::cout << "  CGI Param: " << location._cgi_param << "\n";
+			std::cout << "  Redirect: " << location._redirect.first << " -> " << location._redirect.second << "\n";
+			std::cout << "  Directory Listing: " << (location._dir_listing ? "Enabled" : "Disabled") << "\n";
+			
+			std::cout << "  Methods:\n";
+			for (const auto& method : location._methods)
+				std::cout << "	" << method.first << ": " << (method.second ? "Allowed" : "Not Allowed") << "\n";
+			
+			std::cout << "\n";
+		}
+	}
 	std::cout << "Finished printing configs\n";
 }
 
@@ -97,7 +97,7 @@ std::string ConfigParser::read_file(std::string path)
 
 	if (!filePath.is_absolute()) {
 		fullPath = filePath;
-    }
+	}
 	else {
 		fullPath = std::filesystem::absolute(filePath);
 	}
@@ -134,46 +134,46 @@ std::string ConfigParser::read_file(std::string path)
 // Function to parse the configuration file
 std::vector<std::string> ConfigParser::tokenize(std::string &file_content)
 {
-    std::vector<std::string> tokens;
-    std::stringstream ss(file_content);
-    std::string token, previous;
-    bool semicolon = false;
+	std::vector<std::string> tokens;
+	std::stringstream ss(file_content);
+	std::string token, previous;
+	bool semicolon = false;
 
-    while (ss >> token)
-    {
-        semicolon = false;
-        if (!token.empty() && token.back() == ';')
-        {
-            semicolon = true;
-            token.pop_back();
-        }
-        if (token == "{" || token == "}")
-        {
-            tokens.push_back(token);
-            continue;
-        }
-        if (previous == "host")
-        {
+	while (ss >> token)
+	{
+		semicolon = false;
+		if (!token.empty() && token.back() == ';')
+		{
+			semicolon = true;
+			token.pop_back();
+		}
+		if (token == "{" || token == "}")
+		{
+			tokens.push_back(token);
+			continue;
+		}
+		if (previous == "host")
+		{
 			if (!isValidIP(token))
-            {
+			{
 				std::cerr << "Error: Invalid IP format: " << token << std::endl;
-                return {};
-            }
-        }
+				return {};
+			}
+		}
 		if (previous == "error_page")
 		{
 			tokens.pop_back();
 			token = previous + token;
 		}
-        tokens.push_back(token);
-        if (semicolon)
-            tokens.push_back(";");
-        previous = token;
-    }
-	for (const auto &token : tokens)
-		std::cout << token << std::endl;
+		tokens.push_back(token);
+		if (semicolon)
+			tokens.push_back(";");
+		previous = token;
+	}
+	// for (const auto &token : tokens) // Remnant of initial testing? Delete before submission.
+	// 	std::cout << token << std::endl;
 
-    return tokens;
+	return tokens;
 }
 
 
@@ -270,26 +270,26 @@ void	ConfigParser::checkConfigFilePath(std::string path)
 
 std::map<std::string, Config> ConfigParser::parseConfigFile(std::string path)
 {
-    std::map<std::string, Config> configs;
-    size_t server_count = 0;
-    std::string file_content = read_file(path);
-    std::vector<std::string> tokens = tokenize(file_content);
+	std::map<std::string, Config> configs;
+	size_t server_count = 0;
+	std::string file_content = read_file(path);
+	std::vector<std::string> tokens = tokenize(file_content);
 
-    std::vector<std::string>::const_iterator it = tokens.begin();
-    std::vector<std::string>::const_iterator end = tokens.end();
+	std::vector<std::string>::const_iterator it = tokens.begin();
+	std::vector<std::string>::const_iterator end = tokens.end();
 
-    while (it != end)
-    {
-        if (*it == "server")
-        {
-            Config blockInstance; // new server block
-            
-            assignKeyToValue(++it, end, blockInstance);
-            
-            configs.insert({"Server" + std::to_string(server_count++), blockInstance});
-        }
-        ++it;
-    }
-	testPrintConfigs(configs); // for testing
-    return configs;
+	while (it != end)
+	{
+		if (*it == "server")
+		{
+			Config blockInstance; // new server block
+			
+			assignKeyToValue(++it, end, blockInstance);
+			
+			configs.insert({"Server" + std::to_string(server_count++), blockInstance});
+		}
+		++it;
+	}
+	//testPrintConfigs(configs); // Remnant of initial testing? Delete before submission.
+	return configs;
 }

--- a/sources/Config/ConfigParser.hpp
+++ b/sources/Config/ConfigParser.hpp
@@ -19,43 +19,41 @@ class HttpServer;
 
 enum class ConfigKey
 {
-        LOCATION,
-        END_BLOCK,
-        SEMICOLON,
-        HOST,
-        PORT,
-        SERVER_NAME,
-        ERROR_404,
-        ERROR_500,
-        CLIENT_MAX_BODY_SIZE,
-        UNKNOWN
+	LOCATION,
+	END_BLOCK,
+	SEMICOLON,
+	HOST,
+	PORT,
+	SERVER_NAME,
+	ERROR_404,
+	ERROR_500,
+	CLIENT_MAX_BODY_SIZE,
+	UNKNOWN
 };
 
 const std::unordered_map<std::string, ConfigKey> keywordMap =
 {
-    {"location", ConfigKey::LOCATION},
-    {"}", ConfigKey::END_BLOCK},
-    {";", ConfigKey::SEMICOLON},
-    {"host", ConfigKey::HOST},
-    {"port", ConfigKey::PORT},
-    {"server_name", ConfigKey::SERVER_NAME},
-    {"error_page404", ConfigKey::ERROR_404},
-    {"error_page500", ConfigKey::ERROR_500},
-    {"client_max_body_size", ConfigKey::CLIENT_MAX_BODY_SIZE}
+	{"location", ConfigKey::LOCATION},
+	{"}", ConfigKey::END_BLOCK},
+	{";", ConfigKey::SEMICOLON},
+	{"host", ConfigKey::HOST},
+	{"port", ConfigKey::PORT},
+	{"server_name", ConfigKey::SERVER_NAME},
+	{"error_page404", ConfigKey::ERROR_404},
+	{"error_page500", ConfigKey::ERROR_500},
+	{"client_max_body_size", ConfigKey::CLIENT_MAX_BODY_SIZE}
 };
 
 class ConfigParser { 
 private:
-        ConfigParser() = delete;
-        ConfigParser(const ConfigParser &other) = delete;
-        ConfigParser& operator=(const ConfigParser &other) = delete;
+	ConfigParser() = delete;
+	ConfigParser(const ConfigParser &other) = delete;
+	ConfigParser& operator=(const ConfigParser &other) = delete;
 public:
-        // class member functions
+	// class member functions
 	static std::map<std::string, Config>	parseConfigFile(std::string path);
-    	static void                             checkConfigFilePath(std::string path);
-	static std::string                      read_file(std::string path);
-	static std::vector<std::string>         tokenize(std::string &file_content);
-        static void                             assignKeyToValue(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end,
-                                                                Config &blockInstance);
-
+	static void							checkConfigFilePath(std::string path);
+	static std::string						read_file(std::string path);
+	static std::vector<std::string>			tokenize(std::string &file_content);
+	static void								assignKeyToValue(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance);
 };

--- a/sources/Config/LocationParser.cpp
+++ b/sources/Config/LocationParser.cpp
@@ -61,19 +61,19 @@ void	LocationParser::set_location_methods(std::vector<std::string>::const_iterat
 }
 
 /* struct Location {
-    bool        _dir_listing;
-    std::string _path;
-    std::string _root;
-    std::string _index;
-    std::string _cgi_path;
-    std::string _cgi_param;
-    std::pair<int, std::string> _redirect;
-    std::unordered_map<std::string, bool> _methods;
+	bool		_dir_listing;
+	std::string _path;
+	std::string _root;
+	std::string _index;
+	std::string _cgi_path;
+	std::string _cgi_param;
+	std::pair<int, std::string> _redirect;
+	std::unordered_map<std::string, bool> _methods;
 }; */
 
 std::pair<std::string, Location>	LocationParser::set_location_block(std::vector<std::string>::const_iterator &it, 
-											std::vector<std::string>::const_iterator &end,
-											const std::unordered_map<std::string, Location> &locations)
+	std::vector<std::string>::const_iterator &end,
+	const std::unordered_map<std::string, Location> &locations)
 {
 	Location location_block;
 

--- a/sources/Config/LocationParser.hpp
+++ b/sources/Config/LocationParser.hpp
@@ -7,41 +7,41 @@
 #include <unordered_map>
 
 enum LocationConfigKey {
-    METHODS,
-    AUTOINDEX,
-    REDIR,
-    ROOT,
-    INDEX,
-    CGI_PATH,
-    CGI_PARAM,
-    BREAK
+	METHODS,
+	AUTOINDEX,
+	REDIR,
+	ROOT,
+	INDEX,
+	CGI_PATH,
+	CGI_PARAM,
+	BREAK
 };
 
 static const std::unordered_map<std::string, int> directiveMap = {
-        {"methods", 0},
-        {"autoindex", 1},
-        {"return", 2}, // keyword for redirect
-        {"root", 3},
-        {"index", 4},
-        {"cgi_path", 5},
-        {"cgi_param", 6},
-        {";", 7}
+	{"methods", 0},
+	{"autoindex", 1},
+	{"return", 2}, // keyword for redirect
+	{"root", 3},
+	{"index", 4},
+	{"cgi_path", 5},
+	{"cgi_param", 6},
+	{";", 7}
 };
 
 class LocationParser {
-    private:
-        LocationParser() = delete;
-        LocationParser(const LocationParser &other) = delete;
-        LocationParser& operator=(const LocationParser &other) = delete;
-    public:
-        static std::pair<std::string, Location>	set_location_block(std::vector<std::string>::const_iterator &iterator, 
-												                        std::vector<std::string>::const_iterator &end,
-												                        const std::unordered_map<std::string, Location> &locations);
-		static void                         set_location_methods(std::vector<std::string>::const_iterator &it, std::unordered_map<std::string, bool> methods);
+	private:
+		LocationParser() = delete;
+		LocationParser(const LocationParser &other) = delete;
+		LocationParser& operator=(const LocationParser &other) = delete;
+	public:
+		static std::pair<std::string, Location>	set_location_block(std::vector<std::string>::const_iterator &iterator, 
+		std::vector<std::string>::const_iterator &end,
+		const std::unordered_map<std::string, Location> &locations);
+		static void							set_location_methods(std::vector<std::string>::const_iterator &it, std::unordered_map<std::string, bool> methods);
 		static std::pair<int, std::string>	set_redirect(std::vector<std::string>::const_iterator &it);
 		static std::string					set_location_path(std::vector<std::string>::const_iterator &it);
-		static std::string	                set_root(std::vector<std::string>::const_iterator &it);
-		static std::string	                set_index(std::vector<std::string>::const_iterator &it);
-		static std::string	                set_cgi(std::vector<std::string>::const_iterator &it);
-        static bool			                set_autoindex(std::vector<std::string>::const_iterator &it);
+		static std::string					set_root(std::vector<std::string>::const_iterator &it);
+		static std::string					set_index(std::vector<std::string>::const_iterator &it);
+		static std::string					set_cgi(std::vector<std::string>::const_iterator &it);
+		static bool							set_autoindex(std::vector<std::string>::const_iterator &it);
 };

--- a/sources/Config/ServerConfigData.cpp
+++ b/sources/Config/ServerConfigData.cpp
@@ -4,45 +4,45 @@
 
 ServerConfigData::ServerConfigData()
 {
-    // use default server
+	// use default server
 }
 
 ServerConfigData::ServerConfigData(std::string path) 
 {
-    // needs to set the server configs for each server
-    // ServerConfigBlocks is of datastructure = std::map<std::string, std::vector<Config>>
-    _serverConfigBlocks = ConfigParser::parseConfigFile(path);
-/*     
-    _host.clear();
-    _name.clear();
-    _routes.clear();
-    _ports.clear();
-    _cli_max_bodysize = 0;
-    _location.clear(); */
+	// needs to set the server configs for each server
+	// ServerConfigBlocks is of datastructure = std::map<std::string, std::vector<Config>>
+	_serverConfigBlocks = ConfigParser::parseConfigFile(path);
+/*	 
+	_host.clear();
+	_name.clear();
+	_routes.clear();
+	_ports.clear();
+	_cli_max_bodysize = 0;
+	_location.clear(); */
 
 	std::cout << "New server config data created...: \n";
 }
 
 ServerConfigData::~ServerConfigData() {
-    std::cout << "Server config data instance deleted\n";
+	std::cout << "Server config data instance deleted\n";
 }
 
 std::map<std::string, Config>&	ServerConfigData::getConfigBlocks()
 {
-    return (this->_serverConfigBlocks);
+	return (this->_serverConfigBlocks);
 }
 
 size_t  ServerConfigData::getServerCount()
 {
-    return _serverConfigBlocks.size();
+	return _serverConfigBlocks.size();
 }
 
 size_t  ServerConfigData::getPortCount()
 {
-    size_t portCount = 0;
+	size_t portCount = 0;
 
-    for (const auto& serverInstance : this->_serverConfigBlocks)
-        portCount += serverInstance.second._num_of_ports;
-    std::cout << "num of ports: " << portCount << "\n";
-    return portCount;
+	for (const auto& serverInstance : this->_serverConfigBlocks)
+		portCount += serverInstance.second._num_of_ports;
+	std::cout << "num of ports: " << portCount << "\n";
+	return portCount;
 }

--- a/sources/Config/ServerConfigData.hpp
+++ b/sources/Config/ServerConfigData.hpp
@@ -6,42 +6,42 @@
 #include <string>
 
 struct Location {
-    std::string _path;
-    std::string _root;
-    std::string _index;
-    std::string _cgi_path;
-    std::string _cgi_param;
-    std::pair<int, std::string> _redirect;
-    std::unordered_map<std::string, bool> _methods = {{"GET", false}, {"POST", false}, {"DELETE", false}};
-    bool        _dir_listing;
+	std::string _path;
+	std::string _root;
+	std::string _index;
+	std::string _cgi_path;
+	std::string _cgi_param;
+	std::pair<int, std::string> _redirect;
+	std::unordered_map<std::string, bool> _methods = {{"GET", false}, {"POST", false}, {"DELETE", false}};
+	bool		_dir_listing;
 };
 
 struct Config {
-        std::string					_host;
-        std::vector<std::string>			_names;
-        std::vector<std::string>			_ports;
-        std::unordered_map<std::string, Location>	_location;
-        size_t						_num_of_ports;
-        size_t						_cli_max_bodysize;
-        std::map<int, std::string>			_default_pages;
-        std::vector<std::string>			_error_pages;
-        std::map<int, std::string>			_error_codes;
-        std::map<std::string, std::string>		_cgi_params;
+	std::string									_host;
+	std::vector<std::string>					_names;
+	std::vector<std::string>					_ports;
+	std::unordered_map<std::string, Location>	_location;
+	size_t										_num_of_ports;
+	size_t										_cli_max_bodysize;
+	std::map<int, std::string>					_default_pages;
+	std::vector<std::string>					_error_pages;
+	std::map<int, std::string>					_error_codes;
+	std::map<std::string, std::string>			_cgi_params;
 };
 
 
 class ServerConfigData {
 private:
-        std::map<std::string, Config>   _serverConfigBlocks;
+	std::map<std::string, Config>   _serverConfigBlocks;
 public:
-        ServerConfigData(std::string path);
-        ServerConfigData();
-        ~ServerConfigData();
+	ServerConfigData(std::string path);
+	ServerConfigData();
+	~ServerConfigData();
 
-        std::map<std::string, Config>&   getConfigBlocks();
-        size_t  getServerCount();
-        size_t  getPortCount();
+	std::map<std::string, Config>&   getConfigBlocks();
+	size_t  getServerCount();
+	size_t  getPortCount();
 
-        // class member functions
-        void    printConfigs();
+	// class member functions
+	void	printConfigs();
 };


### PR DESCRIPTION
Comments out main memory error culprit in ConfigParser as well as redundant printing of tokens. Some blocks from config are still reachable though.