### PR TITLE
Adds changes that were omitted during prior merge

### DIFF
--- a/sources/Config/ConfigParser.cpp
+++ b/sources/Config/ConfigParser.cpp
@@ -14,9 +14,8 @@ void	testPrintConfigs(std::map<std::string, Config> configs)
 			std::cout << name << " ";
 		std::cout << "\n";
 		
-		std::cout << "Ports: ";
-		for (const auto& port : config.second._ports)
-			std::cout << port << " ";
+		std::cout << "Port: ";
+		std::cout << config.second._port << " ";
 		std::cout << "\n";
 		
 		std::cout << "Number of Ports: " << config.second._num_of_ports << "\n";

--- a/sources/Config/ServerConfigData.hpp
+++ b/sources/Config/ServerConfigData.hpp
@@ -19,7 +19,7 @@ struct Location {
 struct Config {
 	std::string									_host;
 	std::vector<std::string>					_names;
-	std::vector<std::string>					_ports;
+	std::string									_port;
 	std::unordered_map<std::string, Location>	_location;
 	size_t										_num_of_ports;
 	size_t										_cli_max_bodysize;


### PR DESCRIPTION
Handling conflicts through the github UI is not a good idea... I accidentally deleted some changes, which caused compilation issues, as Config structs _ports vector had been changed to _port string and ConfigParser was still using the vector instead of the string. Note to all: fetch and make sure your sources are up to date when making a branch...