### PR TITLE
changes HttpRequest in t_client into a shared pointer

### DIFF
--- a/includes/ServerHandler.hpp
+++ b/includes/ServerHandler.hpp
@@ -5,15 +5,15 @@
 class HttpServer;
 
 typedef struct s_client {
-	int				fd;
-	std::string		requestString;
-	bool			requestReady;
-	HttpRequest*	request;
-	std::string		responseString;
-	int				responseCode;
-	bool			responseReady;
-	std::time_t		lastRequest;
-	bool			keep_alive;
+	int								fd;
+	std::string						requestString;
+	bool							requestReady;
+	std::shared_ptr<HttpRequest>	request;
+	std::string						responseString;
+	int								responseCode;
+	bool							responseReady;
+	std::time_t						lastRequest;
+	bool							keep_alive;
 } t_client;
 
 class ServerHandler

--- a/sources/Request.cpp
+++ b/sources/Request.cpp
@@ -46,6 +46,7 @@ bool HttpRequestParser::parseRequestLine(const std::string& request_line, HttpRe
 	return true;
 }
 
+
 // Function to parse headers (key: value)
 bool HttpRequestParser::parseHeaders(const std::string& headers_part, HttpRequest& request)
 {

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -117,7 +117,6 @@ void	ServerHandler::closeConnection(size_t& i) {
 	close(clientFd);
 	_pollFds.erase(_pollFds.begin() + i);
 	if (_clients[clientFd].request != nullptr) {
-		delete _clients[clientFd].request;
 		_clients[clientFd].request = nullptr;
 	}
 	_clients.erase(clientFd);
@@ -153,7 +152,7 @@ void	ServerHandler::readRequest(size_t& i)
 
 void	ServerHandler::processRequest(size_t& i) {
 	t_client client = _clients[_pollFds[i].fd];
-	client.request = {};
+	client.request = std::make_unique<HttpRequest>();
 	HttpRequestParser requestParser;
 	
 	try {


### PR DESCRIPTION
This should get rid of the segfault in requestParseLine.