### PR TITLE
fixes process request issue with client going out of scope from method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ webserv
 
 # Local config files
 .vscode/*
+
+# Log files
+*log.txt

--- a/includes/ServerHandler.hpp
+++ b/includes/ServerHandler.hpp
@@ -40,10 +40,9 @@ public:
 	void		addConnection(size_t& i);
 	void		closeConnection(size_t& i);
 	void		readRequest(size_t& i);
-	void		processRequest(size_t& i);
-	void		sendResponse(size_t& i);
+    void		processRequest(size_t& i);
+    void		sendResponse(size_t& i);
 	void		cleanupServers();
-	size_t		getPortCount();
 	static void	signalHandler(int);
 
 	void	printPollFds();

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -150,19 +150,23 @@ void	ServerHandler::readRequest(size_t& i)
 	}
 }
 
-void	ServerHandler::processRequest(size_t& i) {
-	t_client client = _clients[_pollFds[i].fd];
-	client.request = std::make_unique<HttpRequest>();
+void	ServerHandler::processRequest(size_t& i) 
+{
 	HttpRequestParser requestParser;
+	std::shared_ptr<HttpRequest> newRequest(new HttpRequest());
 	
 	try {
-		requestParser.parseRequest(client.requestString, *client.request);
+		requestParser.parseRequest(_clients[_pollFds[i].fd].requestString, *newRequest);
 	} catch (std::exception& e) {
 		throw;
 	}
-	if (client.request->headers.find("Connection") != client.request->headers.end() 
-		&& (client.request->headers["Connection"] == "keep-alive" || client.request->headers["Connection"] == "Keep-Alive"))
-		client.keep_alive = true;
+			
+	_clients[_pollFds[i].fd].request = newRequest;
+	
+	if (_clients[_pollFds[i].fd].request->headers.find("Connection") != _clients[_pollFds[i].fd].request->headers.end() 
+		&& (_clients[_pollFds[i].fd].request->headers["Connection"] == "keep-alive" 
+		|| _clients[_pollFds[i].fd].request->headers["Connection"] == "Keep-Alive"))
+		_clients[_pollFds[i].fd].keep_alive = true;
 }
 
 void	ServerHandler::setPollList()


### PR DESCRIPTION
adds log files to be ignored, deletes unnecessary function in ServerHandler.hpp

processRequest had issue with client going out of scope, so the parsed data only existed within the method call but not in the serverHandler (*this* in screenshot on left in debug panel). Also that means that keep-alive has been false even if it was set to true inside the method, so this would need to be checked/fixed because now it gets stuck in a loop of sending the response. We can look at this tomorrow before merging too.

![Screenshot from 2025-03-24 17-47-31](https://github.com/user-attachments/assets/20970805-20a3-4f60-b24e-ee2c1a50a4e6)
