### PR TITLE
40 config parser error handling and input validation

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -5,6 +5,9 @@ server {
   server_name www.localhost localhost;
   root www;
 
+  # Client body size limit
+  client_max_body_size 10M;
+
   error_page 404 /errors/404.html;
 
   location / {

--- a/sources/Config/ConfigParser.cpp
+++ b/sources/Config/ConfigParser.cpp
@@ -307,35 +307,27 @@ void	ConfigParser::checkConfigFilePath(std::string path)
 
 std::map<std::string, Config> ConfigParser::parseConfigFile(std::string path)
 {
-	try
+	std::map<std::string, Config> configs;
+	size_t server_count = 0;
+	std::string file_content = read_file(path);
+	std::vector<std::string> tokens = tokenize(file_content);
+
+	std::vector<std::string>::const_iterator it = tokens.begin();
+	std::vector<std::string>::const_iterator end = tokens.end();
+
+	while (it != end)
 	{
-		std::map<std::string, Config> configs;
-		size_t server_count = 0;
-		std::string file_content = read_file(path);
-		std::vector<std::string> tokens = tokenize(file_content);
-
-		std::vector<std::string>::const_iterator it = tokens.begin();
-		std::vector<std::string>::const_iterator end = tokens.end();
-
-		while (it != end)
+		if (*it == "server")
 		{
-			if (*it == "server")
-			{
-				Config blockInstance; // new server block
-				
-				assignKeyToValue(++it, end, blockInstance);
-				
-				configs.insert({"Server" + std::to_string(server_count++), blockInstance});
-			}
-			++it;
+			Config blockInstance; // new server block
+			
+			assignKeyToValue(++it, end, blockInstance);
+			
+			configs.insert({"Server" + std::to_string(server_count++), blockInstance});
 		}
-		return configs;
+		++it;
 	}
-	catch (ConfigParserException e)
-	{
-		std::cout << e.what() << std::endl;
-		exit(EXIT_FAILURE);
-	}
+	return configs;
 }
 
 // config parser specific exception

--- a/sources/Config/ConfigParser.hpp
+++ b/sources/Config/ConfigParser.hpp
@@ -56,4 +56,20 @@ public:
 	static std::string						read_file(std::string path);
 	static std::vector<std::string>			tokenize(std::string &file_content);
 	static void								assignKeyToValue(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance);
+
+	class MissingBracketException : public std::exception
+		{
+			public:
+				const char* what() const throw();
+		};
+	class InvalidIPException : public std::exception
+		{
+			public:
+				const char* what() const throw();
+		};
+	class BodySizeOverflowException : public std::exception
+		{
+			public:
+				const char* what() const throw();
+		};
 };

--- a/sources/Config/ConfigParser.hpp
+++ b/sources/Config/ConfigParser.hpp
@@ -57,19 +57,12 @@ public:
 	static std::vector<std::string>			tokenize(std::string &file_content);
 	static void								assignKeyToValue(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance);
 
-	class MissingBracketException : public std::exception
+	class ConfigParserException : public std::exception
 		{
+			private:
+				const char *_message;
 			public:
-				const char* what() const throw();
-		};
-	class InvalidIPException : public std::exception
-		{
-			public:
-				const char* what() const throw();
-		};
-	class BodySizeOverflowException : public std::exception
-		{
-			public:
+				ConfigParserException(const char * msg);
 				const char* what() const throw();
 		};
 };

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -71,16 +71,23 @@ void	ServerHandler::sendResponse(size_t& i)
 	for each virtual server with the appropriate configurations */
 void	ServerHandler::setupServers()
 {
-	for (const auto& [servName, config] : _config.getConfigBlocks()) 
-	{
-		_servers.emplace_back(std::make_shared<HttpServer>(config));
+	try
+	{	
+		for (const auto& [servName, config] : _config.getConfigBlocks()) 
+		{
+			_servers.emplace_back(std::make_shared<HttpServer>(config));
+		}
+		for (const auto& server : _servers)
+		{
+			server->setupAddrinfo();
+		}
+		_serverCount = _servers.size();
 	}
-	for (const auto& server : _servers)
+	catch (ConfigParser::ConfigParserException e)
 	{
-		server->setupAddrinfo();
+		std::cout << e.what() << std::endl;
+		return;
 	}
-	_serverCount = _servers.size();
-
 	// HttpServer  serverInstance(current);
 	// serverInstance.setPorts(current.getPorts());
 	// serverInstance.setNumOfPorts(current.getNumOfPorts());


### PR DESCRIPTION
Adds a custom exception to be thrown while parsing the config file. Exceptions include: overflow checks for numerical values, IP format check, port format check, missing opening bracket in config block, no config file path provided / invalid file path, no permission to open config file.

ServerHandler::setupServers() method wrapped in a try-catch block to catch these exceptions. First tried catching them at the ConfigParser's main loop, but that led into potential memory leaks within the ServerHandler.