### PR TITLE
Request URI query string

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -8,6 +8,8 @@ struct HttpRequest
 {
 	std::string method;										// "GET", "POST", "DELETE"
 	std::string uri;										// e.g. "/index.html"
+	std::string uriQuery;									// query string portion of the URI
+	std::string	uriPath;									// only the path portion of the URI
 	std::string httpVersion;								// e.g. "HTTP/1.1"
 	std::unordered_map<std::string, std::string> headers;	// Header fields
 	std::string body;									// Request body for POST (or PUT) requests

--- a/sources/ConfigParser.cpp
+++ b/sources/ConfigParser.cpp
@@ -67,6 +67,7 @@ std::string trim(const std::string &str)
 bool isValidPort(const std::string &port)
 {
 	int num;
+	(void)num;
 	try
 	{
 		num = std::stoi(port);

--- a/sources/Request.cpp
+++ b/sources/Request.cpp
@@ -39,6 +39,7 @@ bool HttpRequestParser::parseRequestLine(const std::string& request_line, HttpRe
 	if (request.method != "GET" && request.method != "POST" && request.method != "DELETE")
 		return false;  // Unsupported HTTP method
 
+	request.uriPath = request.uri;
 	size_t delimiter = request.uri.find("?");
 	if (delimiter != std::string::npos)
 	{

--- a/sources/Request.cpp
+++ b/sources/Request.cpp
@@ -119,8 +119,5 @@ bool HttpRequestParser::parseRequest(const std::string& raw_request, HttpRequest
 		std::string body_part = raw_request.substr(body_start);
 		parseBody(body_part, request);
 	}
-	std::cout << "request uri: " << request.uri << std::endl;
-	std::cout << "request uriQuery: " << request.uriQuery << std::endl;
-	std::cout << "request uriPath: " << request.uriPath << std::endl;
 	return true;
 }

--- a/sources/Request.cpp
+++ b/sources/Request.cpp
@@ -39,6 +39,13 @@ bool HttpRequestParser::parseRequestLine(const std::string& request_line, HttpRe
 	if (request.method != "GET" && request.method != "POST" && request.method != "DELETE")
 		return false;  // Unsupported HTTP method
 
+	size_t delimiter = request.uri.find("?");
+	if (delimiter != std::string::npos)
+	{
+		request.uriPath = request.uri.substr(0, delimiter);
+		request.uriQuery = request.uri.substr(delimiter + 1);
+	}
+
 	// Validate HTTP version (optional, for simplicity let's assume only HTTP/1.1 for now)
 	if (request.httpVersion != "HTTP/1.1" && request.httpVersion != "HTTP/1.0")
 		return false;  // Invalid HTTP version
@@ -112,5 +119,8 @@ bool HttpRequestParser::parseRequest(const std::string& raw_request, HttpRequest
 		std::string body_part = raw_request.substr(body_start);
 		parseBody(body_part, request);
 	}
+	std::cout << "request uri: " << request.uri << std::endl;
+	std::cout << "request uriQuery: " << request.uriQuery << std::endl;
+	std::cout << "request uriPath: " << request.uriPath << std::endl;
 	return true;
 }


### PR DESCRIPTION
Searches for delimiter "?" in the URI - If found, stores the path part and the query part in their designated string variables in the HttpRequest struct. If no delimiter, leaves the strings empty.