### PR TITLE
Response and client struct refactor

### DIFF
--- a/includes/CGIHandler.hpp
+++ b/includes/CGIHandler.hpp
@@ -2,11 +2,10 @@
 
 #include <vector>
 #include "Request.hpp"
+#include "Client.hpp"
 
 #define READ 0
 #define WRITE 1
-
-struct	s_client;
 
 enum CGIStatus {
 	CGI_UNSET,
@@ -32,12 +31,12 @@ private:
 	// Private class methods
 	void 						closeFds(const std::vector<int> fdsToclose);
 	void 						setCGIEnv(t_CGIrequest &cgiRequest, std::vector<char *> &envp);
-	void 						handleChildProcess(t_CGIrequest request, s_client& client);
+	void 						handleChildProcess(t_CGIrequest request, Client& client);
 	void						handleParentProcess(t_CGIrequest request);
 	std::vector<std::string>	initCGIEnv(HttpRequest& request);
 public:
 	CGIHandler();
 
-	void			setupCGI(s_client& client);
-	void			runCGIScript(s_client& client);
+	void			setupCGI(Client& client);
+	void			runCGIScript(Client& client);
 };

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -1,9 +1,11 @@
+#pragma once
+
 #include <memory>
 #include <ctime>
 #include "Request.hpp"
 #include "Response.hpp"
 
-typedef struct Client {
+struct Client {
 	int								fd;
 	std::string						requestString;
 	bool							requestReady;
@@ -16,7 +18,6 @@ typedef struct Client {
 	int								fileTotalBytesWritten;
 	std::string						responseBodyString;
 	int								responseCode;
-	bool							requestReady;
 	bool							responseReady;
 	std::time_t						lastRequest;
 	bool							keep_alive;

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -1,0 +1,23 @@
+#include <memory>
+#include <ctime>
+#include "Request.hpp"
+#include "Response.hpp"
+
+typedef struct Client {
+	int								fd;
+	std::string						requestString;
+	bool							requestReady;
+	std::unique_ptr<HttpRequest>	request;
+	std::unique_ptr<Response>		response;
+	int								fileSize;
+	int								fileReadFd;
+	int								fileTotalBytesRead;
+	int								fileWriteFd;
+	int								fileTotalBytesWritten;
+	std::string						responseBodyString;
+	int								responseCode;
+	bool							requestReady;
+	bool							responseReady;
+	std::time_t						lastRequest;
+	bool							keep_alive;
+};

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -4,21 +4,25 @@
 #include <ctime>
 #include "Request.hpp"
 #include "Response.hpp"
+// #include "RequestHandler.hpp"
+#include "ResponseHandler.hpp"
 
 struct Client {
-	int								fd;
-	std::string						requestString;
-	bool							requestReady;
-	std::unique_ptr<HttpRequest>	request;
-	std::unique_ptr<Response>		response;
-	int								fileSize;
-	int								fileReadFd;
-	int								fileTotalBytesRead;
-	int								fileWriteFd;
-	int								fileTotalBytesWritten;
-	std::string						responseBodyString;
-	int								responseCode;
-	bool							responseReady;
-	std::time_t						lastRequest;
-	bool							keep_alive;
+	int									fd;
+	std::string							requestString;
+	bool								requestReady;
+	std::unique_ptr<HttpRequest>		request;
+	std::unique_ptr<Response>			response;
+	// std::unique_ptr<RequestHandler>		requestHandler;
+	std::unique_ptr<ResponseHandler>	responseHandler;
+	int									fileSize;
+	int									fileReadFd;
+	int									fileTotalBytesRead;
+	int									fileWriteFd;
+	int									fileTotalBytesWritten;
+	std::string							responseBodyString;
+	int									responseCode;
+	bool								responseReady;
+	std::time_t							lastRequest;
+	bool								keep_alive;
 };

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#define BUFFER_SIZE 1024
+
 struct Response
 {
 	int			statusCode;

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -3,7 +3,10 @@
 struct Response
 {
 	int			statusCode;
+	int			totalBytesSent;
 	std::string	statusLine;
+	std::string	headers;
 	std::string	body;
 	std::string	responseString;
+	bool		responseReady;
 };

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -1,65 +1,9 @@
-// Response.hpp
 #pragma once
 
-#include <iostream>
-#include <iomanip>
-#include <ctime>
-#include <sstream>
-#include <string>
-#include <deque>
-#include <unordered_map>
-#include <ctime>
-#include "Request.hpp"
-#include "HttpServer.hpp"
-
-struct Request;
-
-enum e_status_code
+struct Response
 {
-	STATUS_SUCCESS = 200,
-	STATUS_CREATED = 201,
-	STATUS_NO_CONTENT = 204,
-	STATUS_BAD_REQUEST = 400,
-	STATUS_FORBIDDEN = 403,
-	STATUS_NOT_FOUND = 404,
-	STATUS_NOT_ALLOWED = 405,
-	STATUS_LENGTH_REQUIRED = 411,
-	STATUS_TOO_LARGE = 413,
-	STATUS_URI_TOO_LONG = 414,
-	STATUS_INTERNAL_ERROR = 500,
-	STATUS_NOT_IMPLEMENTED = 501
+	int			statusCode;
+	std::string	statusLine;
+	std::string	body;
+	std::string	responseString;
 };
-
-// Temp placeholders
-#define START_LINE "HTTP/1.1 200 OK\n"
-#define BODY "<!DOCTYPE html><html><head><title>index.html</title></head><body><h1>Hello World!</h1><body></html>"
-
-class Response
-{
-private:
-	HttpRequest& _request;
-	int _statusCode;
-	std::string _statusLine;
-	std::string _body;
-	std::deque<std::string> _headerKeys;
-	std::unordered_map<std::string, std::string> _headers;
-	static std::string getTimeStamp();
-	void formGET();
-	void formPOST();
-	void formDELETE();
-	void formDirectoryListing();
-	void formErrorPage();
-	void addHeader(const std::string& key, const std::string& value);
-	const std::string getStatus() const;
-	const std::string toString() const;
-public:
-	Response(HttpRequest& request);
-	~Response(); 
-	void formResponse();
-	void sendResponse(int clientFd);
-	
-	// RESPONSE EXCEPTION CLASSES BELOW HERE
-
-
-};
-

--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include "Request.hpp"
 #include "Response.hpp"
+#include "Client.hpp"
 #include "HttpServer.hpp"
 
 struct Request;
@@ -33,6 +34,7 @@ enum e_status_code
 class ResponseHandler
 {
 private:
+	const Client& _client;
 	const HttpRequest& _request;
 	std::unique_ptr<Response> _response;
 	static std::string getTimeStamp();
@@ -45,7 +47,7 @@ private:
 	const std::string getStatus() const;
 	const std::string toString() const;
 public:
-	ResponseHandler(const HttpRequest& request);
+	ResponseHandler(const Client& client, const HttpRequest& request);
 	~ResponseHandler(); 
 	void formResponse();
 	void sendResponse(int clientFd);

--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -1,0 +1,59 @@
+// Response.hpp
+#pragma once
+
+#include <iostream>
+#include <iomanip>
+#include <ctime>
+#include <sstream>
+#include <string>
+#include <deque>
+#include <unordered_map>
+#include <ctime>
+#include "Request.hpp"
+#include "Response.hpp"
+#include "HttpServer.hpp"
+
+struct Request;
+
+enum e_status_code
+{
+	STATUS_SUCCESS = 200,
+	STATUS_CREATED = 201,
+	STATUS_NO_CONTENT = 204,
+	STATUS_BAD_REQUEST = 400,
+	STATUS_FORBIDDEN = 403,
+	STATUS_NOT_FOUND = 404,
+	STATUS_NOT_ALLOWED = 405,
+	STATUS_LENGTH_REQUIRED = 411,
+	STATUS_TOO_LARGE = 413,
+	STATUS_URI_TOO_LONG = 414,
+	STATUS_INTERNAL_ERROR = 500,
+	STATUS_NOT_IMPLEMENTED = 501
+};
+
+class ResponseHandler
+{
+private:
+	const HttpRequest& _request;
+	Response& _response;
+	int _totalBytesSent;
+	std::deque<std::string> _headerKeys;
+	std::unordered_map<std::string, std::string> _headers;
+	static std::string getTimeStamp();
+	void formGET();
+	void formPOST();
+	void formDELETE();
+	void formDirectoryListing();
+	void formErrorPage();
+	void addHeader(const std::string& key, const std::string& value);
+	const std::string getStatus() const;
+	const std::string toString() const;
+public:
+	ResponseHandler(const HttpRequest& request);
+	~ResponseHandler(); 
+	void formResponse();
+	void sendResponse(int clientFd);
+	
+	// RESPONSE EXCEPTION CLASSES BELOW HERE
+};
+

--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -6,9 +6,8 @@
 #include <ctime>
 #include <sstream>
 #include <string>
-#include <deque>
-#include <unordered_map>
 #include <ctime>
+#include <memory>
 #include "Request.hpp"
 #include "Response.hpp"
 #include "HttpServer.hpp"
@@ -35,10 +34,7 @@ class ResponseHandler
 {
 private:
 	const HttpRequest& _request;
-	Response& _response;
-	int _totalBytesSent;
-	std::deque<std::string> _headerKeys;
-	std::unordered_map<std::string, std::string> _headers;
+	std::unique_ptr<Response> _response;
 	static std::string getTimeStamp();
 	void formGET();
 	void formPOST();

--- a/includes/ServerHandler.hpp
+++ b/includes/ServerHandler.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <poll.h>
 #include "ServerConfigData.hpp"
+#include "Client.hpp"
 #include "Request.hpp"
 #include "CGIHandler.hpp"
 #include "Logger.hpp"
@@ -14,30 +15,13 @@ class HttpServer;
 #define DEFAULT_CONFIG_FILE "config/default.conf"
 #define BACKLOG 10 // how many pending connections queue will hold
 
-typedef struct s_client {
-	int								fd;
-	std::string						requestString;
-	bool							requestReady;
-	std::unique_ptr<HttpRequest>	request;
-	int								fileSize;
-	int								fileReadFd;
-	int								fileTotalBytesRead;
-	int								fileWriteFd;
-	int								fileTotalBytesWritten;
-	std::string						responseBodyString;
-	int								responseCode;
-	bool							responseReady;
-	std::time_t						lastRequest;
-	bool							keep_alive;
-} t_client;
-
 class ServerHandler
 {
 private:
 	std::vector<std::shared_ptr<HttpServer>>			_servers;
 	size_t					 							_serverCount;
 	std::vector<int>									_ports;
-	std::unordered_map<int, std::unique_ptr<t_client>>	_clients;
+	std::unordered_map<int, std::unique_ptr<Client>>	_clients;
 	std::vector<struct pollfd>							_pollFds;
 	bool												_running;
 	ServerConfigData									_config;

--- a/sources/CGIHandler.cpp
+++ b/sources/CGIHandler.cpp
@@ -49,7 +49,7 @@ void CGIHandler::setCGIEnv(t_CGIrequest &cgiRequest, std::vector<char *> &envp)
 	envp.emplace_back(nullptr);
 }
 
-void	CGIHandler::handleChildProcess(t_CGIrequest cgiRequest, t_client& client)
+void	CGIHandler::handleChildProcess(t_CGIrequest cgiRequest, Client& client)
 {
 	int pipedf[2] = {cgiRequest.pipe[0], cgiRequest.pipe[1]};
 	std::vector<char*> argv;
@@ -92,7 +92,7 @@ void CGIHandler::handleParentProcess(t_CGIrequest request)
 	//close(pipedf[READ]);
 }
 
-void	CGIHandler::runCGIScript(s_client& client)
+void	CGIHandler::runCGIScript(Client& client)
 {
 	t_CGIrequest request = _requests[client.fd]; // gets the client request from container
 
@@ -134,7 +134,7 @@ void	CGIHandler::runCGIScript(s_client& client)
 	}
 }
 
-void	CGIHandler::setupCGI(s_client &client)
+void	CGIHandler::setupCGI(Client &client)
 {
 	// check that the status of the client is correct
 	// add the client to the requests

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -1,10 +1,11 @@
 #include <sys/socket.h>
 #include "Response.hpp"
+#include "ResponseHandler.hpp"
 
 // Constructor
-Response::Response(HttpRequest& request) : 
+ResponseHandler::ResponseHandler(const HttpRequest& request) : 
 	_request(request),
-	_statusCode(0)
+	_totalBytesSent(0)
 {
 	// checkRequest(); // check request errors (eg POST with no type or transfer encoding)
 	// if (!_resolved) checkMethod(); // check method & allowed methods at location
@@ -12,13 +13,12 @@ Response::Response(HttpRequest& request) :
 	// if (!_resolved) checkCGI; // check cgi, execute cgi
 	// if (!_resolved) handleMethod; // handle method
 	// if (!_resolved) _statusCode = STATUS_INTERNAL_ERROR;
-	formResponse();
 }
 
 // Deconstructor
-Response::~Response() {}
+ResponseHandler::~ResponseHandler() {}
 
-void Response::sendResponse(int clientFd) {
+void ResponseHandler::sendResponse(int clientFd) {
 	std::string response = toString();
 	int sendError;
 
@@ -32,16 +32,16 @@ void Response::sendResponse(int clientFd) {
 Adds a key-value pair to _header map and _headerKeys deque. If a header is 
 re-inserted, it is only updated in the map.
 */
-void Response::addHeader(const std::string& key, const std::string& value)
+void ResponseHandler::addHeader(const std::string& key, const std::string& value)
 {
 	if (_headers.find(key) == _headers.end())
 		_headerKeys.emplace_front(key);
 	_headers[key] = (value);
 }
 
-void Response::formResponse()
+void ResponseHandler::formResponse()
 {
-	if (_statusCode >= 300)
+	if (_response.statusCode >= 300)
 		formErrorPage();
 	else if (_request.method == "GET")
 		formGET();
@@ -53,35 +53,35 @@ void Response::formResponse()
 		throw std::runtime_error("Method not implemented exception");
 }
 
-void Response::formGET() {
+void ResponseHandler::formGET() {
 	std::cout << "Forming response: GET\n";
 }
 
-void Response::formPOST() {
+void ResponseHandler::formPOST() {
 	std::cout << "Forming response: POST\n";
 }
 
-void Response::formDELETE() {
+void ResponseHandler::formDELETE() {
 	std::cout << "Forming response: DELETE\n";
 }
 
-void Response::formDirectoryListing() {
+void ResponseHandler::formDirectoryListing() {
 	std::cout << "Forming response: DirectoryListing";
 }
 
-void Response::formErrorPage() {
+void ResponseHandler::formErrorPage() {
 	std::cout << "Forming response: Error Page";
 	std::string status = getStatus();
-	_statusLine = _request.httpVersion + " " + status + "\n";
-	_body = "<html><head><title>" + status + "</title></head><body><center><h1>" + status + "</h1></center><hr><center>webserv</center></body></html>\n";
+	_response.statusLine = _request.httpVersion + " " + status + "\n";
+	_response.body = "<html><head><title>" + status + "</title></head><body><center><h1>" + status + "</h1></center><hr><center>webserv</center></body></html>\n";
 	addHeader("Server", "Webserv v0.6.6.6");
-	addHeader("Content-Length", std::to_string(_body.size()));
+	addHeader("Content-Length", std::to_string(_response.body.size()));
 	addHeader("Content-Type", "text/html");
 	addHeader("Connection", "Closed");
 }
 
-const std::string Response::getStatus() const {
-	switch (_statusCode)
+const std::string ResponseHandler::getStatus() const {
+	switch (_response.statusCode)
 	{
 		case 200:
 			return ("200 OK");
@@ -105,14 +105,13 @@ const std::string Response::getStatus() const {
 			return ("500 Internal Server Error");
 		default :
 			return ("501 Not Implemented");
-
 	}
 }
 
 /*
 Static helper function for getting a timestamp in string format
 */
-std::string Response::getTimeStamp()
+std::string ResponseHandler::getTimeStamp()
 {
 	auto t = std::time(nullptr);
 	auto tm = *std::localtime(&t);
@@ -124,15 +123,15 @@ std::string Response::getTimeStamp()
 /*
 Builds an HTTP response in the form of a single string
 */
-const std::string Response::toString() const
+const std::string ResponseHandler::toString() const
 {
 	std::string response;
 	
-	response += _statusLine;
+	response += _response.statusLine;
 	response += "Date: " + getTimeStamp() + "\n";
 	for (std::string key : _headerKeys)
 		response += key + ": " + _headers.at(key) + "\n";
-	response += "\n" + _body;
+	response += "\n" + _response.body;
 	return response;
 }
 

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -257,67 +257,58 @@ void	ServerHandler::readFromFd(size_t& i) {
 	int bytesRead;
 	char buf[BUFFER_SIZE] = {};
 
-	try {
-		bytesRead = read(client.fileReadFd, buf, BUFFER_SIZE);
-		if (bytesRead <= 0)
-			throw std::runtime_error("Internal Server Error 500: read failed");
-		else {
-			client.responseBodyString.append(buf, bytesRead);
-			client.fileTotalBytesRead += bytesRead;
-			std::cout << "Total bytes read/file size: " << client.fileTotalBytesRead << "/" << client.fileSize << "\n";
-			if (bytesRead < BUFFER_SIZE)
-			{
-				if (client.fileTotalBytesRead != client.fileSize)
-					throw std::runtime_error("Internal Server Error 500: read failed");
-				client.responseReady = true;
-				std::cout << "Client [" << client.fd << "] response body read: " << client.responseBodyString << "\n";
-				close(client.fileReadFd);
-				client.fileReadFd = -1;
-			}
-			else
-			{
-				std::cout << "Client [" << client.fd << "] read " << bytesRead << " bytes from disk, continuing...\n";
-				_pollFds[i].revents = POLL_OUT;
-			}
+	bytesRead = read(client.fileReadFd, buf, BUFFER_SIZE);
+	if (bytesRead <= 0)
+		throw std::runtime_error("Internal Server Error 500: read failed");
+	else {
+		client.responseBodyString.append(buf, bytesRead);
+		client.fileTotalBytesRead += bytesRead;
+		std::cout << "Total bytes read/file size: " << client.fileTotalBytesRead << "/" << client.fileSize << "\n";
+		if (bytesRead < BUFFER_SIZE)
+		{
+			if (client.fileTotalBytesRead != client.fileSize)
+				throw std::runtime_error("Internal Server Error 500: read failed");
+			client.responseReady = true;
+			std::cout << "Client [" << client.fd << "] response body read: " << client.responseBodyString << "\n";
+			close(client.fileReadFd);
+			client.fileReadFd = -1;
 		}
-	} catch (std::exception &e) {
-		throw e;
+		else
+		{
+			std::cout << "Client [" << client.fd << "] read " << bytesRead << " bytes from disk, continuing...\n";
+			_pollFds[i].revents = POLL_OUT;
+		}
 	}
-
 }
 
 void	ServerHandler::writeToFd(size_t& i) {
 	Client& client = *_clients[_pollFds[i].fd].get();
 	int bytesWritten;
-	size_t leftToWrite = client.fileSize -client.fileTotalBytesWritten;
+	size_t leftToWrite = client.fileSize - client.fileTotalBytesWritten;
 	size_t bytesToWrite = leftToWrite > BUFFER_SIZE ? BUFFER_SIZE : leftToWrite;
 	char buf[BUFFER_SIZE] = {};
 	client.request->body.copy(buf, BUFFER_SIZE, client.fileTotalBytesWritten);
 
-	try {
-		bytesWritten = write(client.fileWriteFd, buf, bytesToWrite);
-		if (bytesWritten <= 0)
-			throw std::runtime_error("Internal Server Error 500: write failed");
-		else {
-			client.fileTotalBytesWritten += bytesWritten;
-			std::cout << "Total bytes written/file size: " << client.fileTotalBytesWritten << "/" << client.fileSize << "\n";
-			if (bytesWritten < BUFFER_SIZE)
-			{
-				if (client.fileTotalBytesWritten != client.fileSize)
-					throw std::runtime_error("Internal Server Error 500: write failed");
-				client.responseReady = true;
-				std::cout << "Client [" << client.fd << "] POST request resource saved to disk\n";
-				close(client.fileWriteFd);
-				client.fileWriteFd = -1;
-			}
-			else
-			{
-				std::cout << "Client [" << client.fd << "] wrote " << bytesWritten << " bytes to disk, continuing...\n";
-				_pollFds[i].revents = POLL_OUT;
-			}
+	bytesWritten = write(client.fileWriteFd, buf, bytesToWrite);
+	if (bytesWritten <= 0)
+		throw std::runtime_error("Internal Server Error 500: write failed");
+	else {
+		client.fileTotalBytesWritten += bytesWritten;
+		std::cout << "Total bytes written/file size: " << client.fileTotalBytesWritten << "/" << client.fileSize << "\n";
+		if (bytesWritten < BUFFER_SIZE)
+		{
+			if (client.fileTotalBytesWritten != client.fileSize)
+				throw std::runtime_error("Internal Server Error 500: write failed");
+			client.responseReady = true;
+			std::cout << "Client [" << client.fd << "] POST request resource saved to disk\n";
+			close(client.fileWriteFd);
+			client.fileWriteFd = -1;
 		}
-	} catch (std::exception &e) {
-		throw e;
+		else
+		{
+			std::cout << "Client [" << client.fd << "] wrote " << bytesWritten << " bytes to disk, continuing...\n";
+			_pollFds[i].revents = POLL_OUT;
+		}
 	}
 }
 

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -102,7 +102,7 @@ void	ServerHandler::addConnection(size_t& i) {
 		new_pollfd.events = POLLIN | POLLOUT;
 		new_pollfd.revents = 0;
 		_pollFds.emplace_back(new_pollfd);
-		_clients[clientFd] = std::make_unique<t_client>();
+		_clients[clientFd] = std::make_unique<Client>();
 		_clients[clientFd]->fd = clientFd;
 	} catch (std::exception& e) {
 		_clients[clientFd]->responseCode = 500;
@@ -150,7 +150,7 @@ void	ServerHandler::readRequest(size_t& i)
 
 void	ServerHandler::processRequest(size_t& i) 
 {
-	t_client& client = *_clients[_pollFds[i].fd].get();
+	Client& client = *_clients[_pollFds[i].fd].get();
 	HttpRequestParser requestParser;
 	client.request = std::make_unique<HttpRequest>();
 	
@@ -253,7 +253,7 @@ void	ServerHandler::pollLoop()
 }
 
 void	ServerHandler::readFromFd(size_t& i) {
-	t_client& client = *_clients[_pollFds[i].fd].get();
+	Client& client = *_clients[_pollFds[i].fd].get();
 	int bytesRead;
 	char buf[BUFFER_SIZE] = {};
 
@@ -287,7 +287,7 @@ void	ServerHandler::readFromFd(size_t& i) {
 }
 
 void	ServerHandler::writeToFd(size_t& i) {
-	t_client& client = *_clients[_pollFds[i].fd].get();
+	Client& client = *_clients[_pollFds[i].fd].get();
 	int bytesWritten;
 	size_t leftToWrite = client.fileSize -client.fileTotalBytesWritten;
 	size_t bytesToWrite = leftToWrite > BUFFER_SIZE ? BUFFER_SIZE : leftToWrite;

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -5,7 +5,7 @@ int main(int argc, char **argv)
 {
 	if (argc > 2)
 	{
-		std::cerr << "Usage: " << std::string(argv[0]) << "[config file path]\n";
+		std::cerr << "Usage: " << std::string(argv[0]) << " [config file path]\n";
 		return 2;
 	}
 	try


### PR DESCRIPTION
First step in refactoring general structure. Response becomes ResponseHandler with an internal Response struct. Client struct is moved to its own file and changes to name are implemented also on the CGI side. ResponsHandler is not yet used in ServerHandler, so functionality is still following previous logic and works as before.