### PR TITLE
Moves HttpRequest to its own header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OBJECT_PATHS		:= $(addprefix $(OBJECT_DIRECTORY), $(OBJECTS))
 
 # Includes
 INCLUDE_DIRECTORY	:= includes/
-INCLUDES			:= webserv.hpp RequestHandler.hpp RequestParser.hpp Response.hpp HttpServer.hpp ServerHandler.hpp CGIHandler.hpp ResponseHandler.hpp
+INCLUDES			:= webserv.hpp RequestHandler.hpp RequestParser.hpp HttpResponse.hpp HttpServer.hpp ServerHandler.hpp CGIHandler.hpp ResponseHandler.hpp
 
 INCLUDE_PATHS		:= $(addprefix $(INCLUDE_DIRECTORY), $(INCLUDES))
 INCLUDE_FLAGS		:= -I includes/

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -2,8 +2,9 @@
 
 #include <memory>
 #include <ctime>
+#include "HttpRequest.hpp"
 #include "RequestHandler.hpp"
-#include "Response.hpp"
+#include "HttpResponse.hpp"
 #include "ResponseHandler.hpp"
 
 class ResponseHandler;
@@ -13,9 +14,9 @@ struct Client {
 	std::string							requestString;
 	bool								requestReady;
 	std::unique_ptr<HttpRequest>		request;
-	std::unique_ptr<Response>			response;
+	std::unique_ptr<HttpResponse>			response;
 	std::unique_ptr<ResponseHandler>	responseHandler;
-	// std::unique_ptr<RequestHandler>		requestHandler;
+	std::unique_ptr<RequestHandler>		requestHandler;
 	int									fileSize;
 	int									fileReadFd;
 	int									fileTotalBytesRead;

--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <iostream>
+#include <unordered_map>
+
+struct HttpRequest
+{
+	std::string method;										// "GET", "POST", "DELETE"
+	std::string uri;										// e.g. "/index.html"
+	std::string uriQuery;									// query string portion of the URI
+	std::string	uriPath;									// only the path portion of the URI
+	std::string httpVersion;								// e.g. "HTTP/1.1"
+	std::unordered_map<std::string, std::string> headers;	// Header fields
+	std::string body;										// Request body for POST (or PUT) requests
+};

--- a/includes/HttpResponse.hpp
+++ b/includes/HttpResponse.hpp
@@ -4,7 +4,7 @@
 
 #define BUFFER_SIZE 1024
 
-struct Response
+struct HttpResponse
 {
 	int			statusCode;
 	int			totalBytesSent;

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -1,18 +1,7 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
-
-struct HttpRequest
-{
-	std::string method;										// "GET", "POST", "DELETE"
-	std::string uri;										// e.g. "/index.html"
-	std::string uriQuery;									// query string portion of the URI
-	std::string	uriPath;									// only the path portion of the URI
-	std::string httpVersion;								// e.g. "HTTP/1.1"
-	std::unordered_map<std::string, std::string> headers;	// Header fields
-	std::string body;										// Request body for POST (or PUT) requests
-};
+#include "HttpRequest.hpp"
 
 class RequestHandler
 {

--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -8,8 +8,8 @@
 #include <string>
 #include <ctime>
 #include <memory>
-// #include "Request.hpp"
-#include "Response.hpp"
+#include "HttpRequest.hpp"
+#include "HttpResponse.hpp"
 #include "Client.hpp"
 #include "HttpServer.hpp"
 
@@ -37,7 +37,7 @@ class ResponseHandler
 private:
 	const Client& _client;
 	const HttpRequest& _request;
-	std::unique_ptr<Response> _response;
+	std::unique_ptr<HttpResponse> _response;
 	static std::string getTimeStamp();
 	void formGET();
 	void formPOST();

--- a/sources/CGIHandler.cpp
+++ b/sources/CGIHandler.cpp
@@ -2,9 +2,9 @@
 #include <sys/stat.h>
 #include <exception>
 #include <iostream>
-#include "ServerHandler.hpp"
-#include "CGIHandler.hpp"
 #include <filesystem>
+#include "CGIHandler.hpp"
+#include "HttpRequest.hpp"
 
 CGIHandler::CGIHandler()
 {

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -1,5 +1,4 @@
 #include <sys/socket.h>
-#include "Response.hpp"
 #include "ResponseHandler.hpp"
 
 // Constructor


### PR DESCRIPTION
Moves HttpRequest out of RequestHandler so that other classes that need the struct can include only said header. Fixes any related includes. Also renames Response to HttpResponse to match HttpRequest and HttpServer.

Closes #67 