### PR TITLE
Send response fix

### DIFF
--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -12,14 +12,16 @@ class RequestHandler
 		std::unique_ptr<HttpRequest> _request;
 		Client& _client;
 		std::string _requestString;
-		bool _requestReady;
+		bool _readReady;
 		// bool _chunkedRequest;
-		// bool _chunkedRequestReady;
+		// std::string _chunkedBodyString;
+		// // bool _chunkedRequestReady;
 	public:
 		RequestHandler(Client& client);
 		~RequestHandler();
 		void readRequest();
 		void processRequest();
+		void resetHandler();
 
 		const HttpRequest &getRequest() const;
 		// Not sure if the getters below are needed, as most of the work will be done with the whole struct from above

--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -20,7 +20,6 @@ class ResponseHandler
 private:
 	Client& _client;
 	std::unique_ptr<HttpResponse> _response;
-	static std::string getTimeStamp();
 	void formGET();
 	void formPOST();
 	void formDELETE();
@@ -31,11 +30,12 @@ private:
 	void addHeader(const std::string& key, const std::string& value);
 	void addBody(const std::string& bodyString);
 	void makeResponseString();
+	static std::string getTimeStamp();
 public:
 	ResponseHandler(Client& client);
-	~ResponseHandler(); 
-	void formResponse();
+	~ResponseHandler();
 	void sendResponse();
+	void formResponse();
 	
 	class SendError : public std::exception {
 		public:

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -11,8 +11,8 @@ RequestHandler::~RequestHandler() {}
 RequestHandler::RequestHandler(Client& client) : 
 	_client(client),
 	_requestString(""),
-	_requestReady(false)
-	// _chunkedRequest(false),
+	_readReady(false)
+	// _chunkedRequest(false)
 	// _chunkedRequestReady(false) 
 	{}
 
@@ -28,12 +28,12 @@ void RequestHandler::readRequest() {
 	else {
 		_requestString.append(buf, receivedBytes);
 		if (receivedBytes < BUFFER_SIZE) { // whole request read
-			_requestReady = true;
-			std::cout << "Client [" << _client.fd << "] request ready: " << _requestString << "\n";
+			_readReady = true;
+			std::cout << "Client " << _client.fd << " complete request received!\n";
 			processRequest();
 		}
 		else // more incoming
-			std::cout << "Received request portion: " << buf << "\n";
+			std::cout << "Client " << _client.fd << " received request portion:\n" << buf << "\n";
 	}
 }
 
@@ -63,6 +63,11 @@ void RequestHandler::processRequest() {
 		_client.fileWriteFd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NONBLOCK, 0644);
 		std::cout << "Requested file path: " << path << ", and size of file: " << _client.fileSize << "\n";
 	}
+}
+
+void RequestHandler::resetHandler() {
+	_requestString = "";
+	_readReady = false;
 }
 
 const HttpRequest &RequestHandler::getRequest() const


### PR DESCRIPTION
Adds functions to reset client and requestHandler. Fixes poll loop so server sockets are never treated as client sockets. Enables checkClient in poll loop. Fixes ResponseHandler::sendResponse structure by removing send buffer entirely.