### PR TITLE
Config parser error pages

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -9,6 +9,7 @@ server {
   client_max_body_size 10M;
 
   error_page 404 /errors/404.html;
+  error_page 500 /errors/500.html;
 
   location / {
     index index.html;

--- a/includes/ConfigParser.hpp
+++ b/includes/ConfigParser.hpp
@@ -91,6 +91,7 @@ public:
 	static std::vector<std::string>			tokenize(std::string &file_content);
 	static void								assignKeyToValue(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance);
 	static void								assignErrorPage(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance, ConfigKey key);
+	static void								setDefaultErrorPages(Config &blockInstance);
 
 	class ConfigParserException : public std::exception
 		{

--- a/includes/ConfigParser.hpp
+++ b/includes/ConfigParser.hpp
@@ -23,8 +23,26 @@ enum class ConfigKey
 	HOST,
 	PORT,
 	SERVER_NAME,
+	ERROR_200,
+	ERROR_201,
+	ERROR_202,
+	ERROR_204,
+	ERROR_301,
+	ERROR_307,
+	ERROR_308,
+	ERROR_400,
+	ERROR_403,
 	ERROR_404,
+	ERROR_405,
+	ERROR_408,
+	ERROR_411,
+	ERROR_413,
+	ERROR_414,
+	ERROR_415,
+	ERROR_418,
+	ERROR_431,
 	ERROR_500,
+	ERROR_501,
 	CLIENT_MAX_BODY_SIZE,
 	UNKNOWN
 };
@@ -37,8 +55,26 @@ const std::unordered_map<std::string, ConfigKey> keywordMap =
 	{"host", ConfigKey::HOST},
 	{"port", ConfigKey::PORT},
 	{"server_name", ConfigKey::SERVER_NAME},
+	{"error_page200", ConfigKey::ERROR_200},
+	{"error_page201", ConfigKey::ERROR_201},
+	{"error_page202", ConfigKey::ERROR_202},
+	{"error_page204", ConfigKey::ERROR_204},
+	{"error_page301", ConfigKey::ERROR_301},
+	{"error_page307", ConfigKey::ERROR_307},
+	{"error_page308", ConfigKey::ERROR_308},
+	{"error_page400", ConfigKey::ERROR_400},
+	{"error_page403", ConfigKey::ERROR_403},
 	{"error_page404", ConfigKey::ERROR_404},
+	{"error_page405", ConfigKey::ERROR_405},
+	{"error_page408", ConfigKey::ERROR_408},
+	{"error_page411", ConfigKey::ERROR_411},
+	{"error_page413", ConfigKey::ERROR_413},
+	{"error_page414", ConfigKey::ERROR_414},
+	{"error_page415", ConfigKey::ERROR_415},
+	{"error_page418", ConfigKey::ERROR_418},
+	{"error_page431", ConfigKey::ERROR_431},
 	{"error_page500", ConfigKey::ERROR_500},
+	{"error_page501", ConfigKey::ERROR_501},
 	{"client_max_body_size", ConfigKey::CLIENT_MAX_BODY_SIZE}
 };
 
@@ -50,10 +86,11 @@ private:
 public:
 	// class member functions
 	static std::map<std::string, Config>	parseConfigFile(std::string path);
-	static void							checkConfigFilePath(std::string path);
+	static void								checkConfigFilePath(std::string path);
 	static std::string						read_file(std::string path);
 	static std::vector<std::string>			tokenize(std::string &file_content);
 	static void								assignKeyToValue(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance);
+	static void								assignErrorPage(std::vector<std::string>::const_iterator &it, std::vector<std::string>::const_iterator &end, Config &blockInstance, ConfigKey key);
 
 	class ConfigParserException : public std::exception
 		{

--- a/includes/ServerConfigData.hpp
+++ b/includes/ServerConfigData.hpp
@@ -23,8 +23,8 @@ struct Config {
 	std::unordered_map<std::string, Location>	_location;
 	size_t										_cli_max_bodysize;
 	std::map<int, std::string>					_default_pages;
-	std::vector<std::string>					_error_pages;
-	std::map<int, std::string>					_error_codes;
+	std::map<int, std::string>					_error_pages;
+	//std::map<int, std::string>					_error_codes; // unnecessary?
 };
 
 class ServerConfigData {

--- a/sources/ConfigParser.cpp
+++ b/sources/ConfigParser.cpp
@@ -213,12 +213,26 @@ void ConfigParser::assignErrorPage(std::vector<std::string>::const_iterator &it,
 	Config &blockInstance, ConfigKey key)
 {
 	static const std::map<ConfigKey, int> keyToCode = {
+		{ ConfigKey::ERROR_200, 200 },
+		{ ConfigKey::ERROR_201, 201 },
+		{ ConfigKey::ERROR_202, 202 },
+		{ ConfigKey::ERROR_204, 204 },
+		{ ConfigKey::ERROR_301, 301 },
+		{ ConfigKey::ERROR_307, 307 },
+		{ ConfigKey::ERROR_308, 308 },
+		{ ConfigKey::ERROR_400, 400 },
+		{ ConfigKey::ERROR_403, 403 },
 		{ ConfigKey::ERROR_404, 404 },
+		{ ConfigKey::ERROR_405, 405 },
+		{ ConfigKey::ERROR_408, 408 },
+		{ ConfigKey::ERROR_411, 411 },
+		{ ConfigKey::ERROR_413, 413 },
+		{ ConfigKey::ERROR_415, 415 },
+		{ ConfigKey::ERROR_418, 418 },
+		{ ConfigKey::ERROR_431, 431 },
 		{ ConfigKey::ERROR_500, 500 },
-		// all pages here
+		{ ConfigKey::ERROR_501, 501 },
 	};
-
-	// set to default here if page not specified?
 
 	auto itCode = keyToCode.find(key);
 	if (itCode != keyToCode.end()) {
@@ -230,6 +244,32 @@ void ConfigParser::assignErrorPage(std::vector<std::string>::const_iterator &it,
 	}
 }
 
+void ConfigParser::setDefaultErrorPages(Config &blockInstance)
+{
+	static const std::map<int, std::string> defaultPages = {
+		{301, "/errors/301.html"},
+		{307, "/errors/307.html"},
+		{308, "/errors/308.html"},
+		{400, "/errors/400.html"},
+		{403, "/errors/403.html"},
+		{404, "/errors/404.html"},
+		{405, "/errors/405.html"},
+		{408, "/errors/408.html"},
+		{411, "/errors/411.html"},
+		{413, "/errors/413.html"},
+		{415, "/errors/415.html"},
+		{418, "/errors/418.html"},
+		{431, "/errors/431.html"},
+		{500, "/errors/500.html"},
+		{501, "/errors/501.html"}
+	};
+
+	for (const auto& entry : defaultPages)
+	{
+		if (blockInstance._error_pages.find(entry.first) == blockInstance._error_pages.end())
+			blockInstance._error_pages[entry.first] = entry.second;
+	}
+}
 
 
 void ConfigParser::assignKeyToValue(std::vector<std::string>::const_iterator &it, 
@@ -342,6 +382,7 @@ std::map<std::string, Config> ConfigParser::parseConfigFile(std::string path)
 			Config blockInstance; // new server block
 			
 			assignKeyToValue(++it, end, blockInstance);
+			setDefaultErrorPages(blockInstance);
 			
 			configs.insert({"Server" + std::to_string(server_count++), blockInstance});
 		}

--- a/var/www/html/errors/301.html
+++ b/var/www/html/errors/301.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>301 Moved Permanently</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 50px; }
+    h1 { font-size: 48px; color: #336699; }
+  </style>
+</head>
+<body>
+  <h1>301</h1>
+  <p>The requested resource has been permanently moved to a new location.</p>
+</body>
+</html>

--- a/var/www/html/errors/307.html
+++ b/var/www/html/errors/307.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>307 Temporary Redirect</title>
+  <style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #336699; }</style>
+</head>
+<body>
+  <h1>307</h1>
+  <p>This resource has been temporarily moved. Please retry using the new URL.</p>
+</body>
+</html>

--- a/var/www/html/errors/308.html
+++ b/var/www/html/errors/308.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>308 Permanent Redirect</title>
+  <style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #336699; }</style>
+</head>
+<body>
+  <h1>308</h1>
+  <p>This resource has permanently moved. Use the new URL provided.</p>
+</body>
+</html>

--- a/var/www/html/errors/400.html
+++ b/var/www/html/errors/400.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>400 Bad Request</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>400</h1>
+  <p>Your request was malformed or invalid.</p>
+</body>
+</html>

--- a/var/www/html/errors/405.html
+++ b/var/www/html/errors/405.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>405 Method Not Allowed</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>405</h1>
+  <p>The method used in the request is not allowed for this resource.</p>
+</body>
+</html>

--- a/var/www/html/errors/408.html
+++ b/var/www/html/errors/408.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>408 Request Timeout</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>408</h1>
+  <p>Your request timed out. Please try again later.</p>
+</body>
+</html>

--- a/var/www/html/errors/411.html
+++ b/var/www/html/errors/411.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>411 Length Required</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>411</h1>
+  <p>The request did not specify a required Content-Length header.</p>
+</body>
+</html>

--- a/var/www/html/errors/413.html
+++ b/var/www/html/errors/413.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>413 Payload Too Large</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>413</h1>
+  <p>The request payload is too large to process.</p>
+</body>
+</html>

--- a/var/www/html/errors/415.html
+++ b/var/www/html/errors/415.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>415 Unsupported Media Type</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>415</h1>
+  <p>The server does not support the media type transmitted in the request.</p>
+</body>
+</html>

--- a/var/www/html/errors/418.html
+++ b/var/www/html/errors/418.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>418 I'm a teapot</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #996633; }</style></head>
+<body>
+  <h1>418</h1>
+  <p>I'm a teapot. I refuse to brew coffee because I am, permanently, a teapot.</p>
+</body>
+</html>

--- a/var/www/html/errors/431.html
+++ b/var/www/html/errors/431.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>431 Request Header Fields Too Large</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>431</h1>
+  <p>Request header fields are too large. Try reducing the size and resending.</p>
+</body>
+</html>

--- a/var/www/html/errors/501.html
+++ b/var/www/html/errors/501.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>501 Not Implemented</title>
+<style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
+<body>
+  <h1>501</h1>
+  <p>This server does not recognize or support the request method.</p>
+</body>
+</html>


### PR DESCRIPTION
Sets custom error page according to config. If not provided, uses default pages in var/www/html/errors/