### PR TITLE
Adds function that returns the MIME type of a file

### DIFF
--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -22,6 +22,7 @@ class RequestHandler
 		void readRequest();
 		void processRequest();
 		void resetHandler();
+		static std::string getMIMEType(const std::string& filePath); 
 
 		const HttpRequest &getRequest() const;
 		// Not sure if the getters below are needed, as most of the work will be done with the whole struct from above

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -73,6 +73,44 @@ void RequestHandler::resetHandler() {
 	_readReady = false;
 }
 
+std::string RequestHandler::getMIMEType(const std::string& filePath) {
+	size_t extensionStart = filePath.find_last_of(".");
+	if (extensionStart == std::string::npos)
+		throw ServerException(STATUS_TYPE_UNSUPPORTED);
+	std::string extension = filePath.substr(extensionStart);
+	if (extension.empty())
+		throw ServerException(STATUS_TYPE_UNSUPPORTED);
+	
+	// Defines MIME types, can be added to
+		std::unordered_map<std::string, std::string> types = {
+		{".html", "text/html"},
+		{".htm", "text/html"},
+		{".css", "text/css"},
+		{".js", "application/javascript"},
+		{".json", "application/json"},
+		{".png", "image/png"},
+		{".jpg", "image/jpeg"},
+		{".jpeg", "image/jpeg"},
+		{".gif", "image/gif"},
+		{".bmp", "image/bmp"},
+		{".svg", "image/svg+xml"},
+		{".txt", "text/plain"},
+		{".xml", "application/xml"},
+		{".pdf", "application/pdf"},
+		{".zip", "application/zip"},
+		{".mp3", "audio/mpeg"},
+		{".mp4", "video/mp4"},
+		{".avi", "video/x-msvideo"},
+		{".csv", "text/csv"},
+		{".md", "text/markdown"}
+	};
+
+	auto type = types.find(extension);
+	if (type == types.end())
+		throw ServerException(STATUS_TYPE_UNSUPPORTED);
+	return type->second;
+}
+
 const HttpRequest &RequestHandler::getRequest() const
 {
 	return *_request;
@@ -89,17 +127,17 @@ const std::string &RequestHandler::getBody() const { return _request->body; }
 
 // int main()
 // {
-//     std::string raw_request = "GET /index.html HTTP/1.1\r\n"
-//                               "Host: example.com\r\n"
-//                               "User-Agent: CustomClient/1.0\r\n"
-//                               "\r\n";
+//	 std::string raw_request = "GET /index.html HTTP/1.1\r\n"
+//							   "Host: example.com\r\n"
+//							   "User-Agent: CustomClient/1.0\r\n"
+//							   "\r\n";
 
-//     RequestHandler req1(raw_request);
-//     const HttpRequest &request = req1.getRequest();
-//     std::cout << request.httpVersion << std::endl;
-//     std::cout << request.uri << std::endl;
-//     std::cout << request.method << std::endl;
-//     std::cout << request.uriPath << std::endl;
+//	 RequestHandler req1(raw_request);
+//	 const HttpRequest &request = req1.getRequest();
+//	 std::cout << request.httpVersion << std::endl;
+//	 std::cout << request.uri << std::endl;
+//	 std::cout << request.method << std::endl;
+//	 std::cout << request.uriPath << std::endl;
 
-//     std::cout << req1.getUri() << std::endl;
+//	 std::cout << req1.getUri() << std::endl;
 // }

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -78,8 +78,6 @@ std::string RequestHandler::getMIMEType(const std::string& filePath) {
 	if (extensionStart == std::string::npos)
 		throw ServerException(STATUS_TYPE_UNSUPPORTED);
 	std::string extension = filePath.substr(extensionStart);
-	if (extension.empty())
-		throw ServerException(STATUS_TYPE_UNSUPPORTED);
 	
 	// Defines MIME types, can be added to
 		std::unordered_map<std::string, std::string> types = {


### PR DESCRIPTION
Adds a static method to RequestHandler that matches to a MIME type based on the file extension of a file path given as an argument and returns the MIME type. Throws a ServerError with 415 - Unsupported Media if file extension does not or does not match.

Closes #73 