### PR TITLE
Fix/method permissions hangs

### DIFF
--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -112,7 +112,7 @@ void ResponseHandler::formDirectoryListing() {
 	std::string rootlessPath = _client.resourcePath.substr(rootLen);
 	if (rootlessPath != "/") {
 		if (rootlessPath.back() == '/')
-			rootlessPath.erase(rootlessPath.back());
+			rootlessPath.erase(rootlessPath.end() - 1);
 		rootlessPath.erase(rootlessPath.find_last_of('/') + 1);
 		dirlistStream << "<tr>\n<td><a href=\"" << rootlessPath << "\" />../</a></td>\n<td></td>\n<td>-</td>\n</tr>\n";
 	}

--- a/sources/ServerConfigData.cpp
+++ b/sources/ServerConfigData.cpp
@@ -69,9 +69,10 @@ bool ServerConfigData::checkMethod(const Config& config, const std::string& meth
 		if (path.size() > 1 && path.back() == '/')
 			path.erase(path.begin() + path.find_last_of('/'), path.end());
 		const Location* location = getLocation(config, path);
-		if (location != nullptr && location->methods.at(method)) {
+		if (location != nullptr && location->methods.at(method))
 			return true;
-		}
+		if (path == "/")
+			break;
 		path.erase(path.begin() + path.find_last_of('/') + 1, path.end());
 	}
 	return false;


### PR DESCRIPTION
Fixes cases where checkMethod hangs if requested method is not allowed even at root level.
Also fixes error where creation of a link for directory listing would cause a loop.