### PR TITLE
Fix/sigint handling

### DIFF
--- a/includes/ResponseHandler.hpp
+++ b/includes/ResponseHandler.hpp
@@ -37,6 +37,7 @@ private:
 public:
 	ResponseHandler(Client& client);
 	~ResponseHandler();
+	void resetHandler();
 	void sendResponse();
 	void formResponse();
 };

--- a/includes/ServerHandler.hpp
+++ b/includes/ServerHandler.hpp
@@ -25,13 +25,13 @@ enum PollType
 class ServerHandler
 {
 private:
-	static std::vector<std::unique_ptr<HttpServer>>		_servers;
-	size_t					 							_serverCount;
+	static bool											_sigintReceived;
+	size_t												_serverCount;
 	std::vector<int>									_ports;
+	std::vector<std::unique_ptr<HttpServer>>			_servers;
 	std::unordered_map<int, std::unique_ptr<Client>>	_clients;
 	std::unordered_map<int, Client*>					_resourceFds;
 	std::vector<struct pollfd>							_pollFds;
-	bool												_running;
 	ServerConfigData									_config;
 	Logger												_fileLogger;
 	Logger												_consoleLogger;

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -5,10 +5,14 @@
 #include "ServerException.hpp"
 
 // Constructor
-ResponseHandler::ResponseHandler(Client& client) : _client(client) {}
+ResponseHandler::ResponseHandler(Client& client) : _client(client), _totalBytesSent(0) {}
 
 // Deconstructor
 ResponseHandler::~ResponseHandler() {}
+
+void ResponseHandler::resetHandler() {
+	_totalBytesSent = 0;
+}
 
 void ResponseHandler::sendResponse() {
 	if (!_client.responseReady)

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -102,6 +102,7 @@ void ServerHandler::resetClient(Client& client) {
 	client.responseSent = false;
 	client.responseCode = STATUS_OK;
 	client.requestHandler->resetHandler();
+	client.responseHandler->resetHandler();
 }
 
 void ServerHandler::removeFromPollList(int fdToRemove)

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -12,7 +12,14 @@
 
 #define BACKLOG 10 // how many pending connections queue will hold
 
-std::vector<std::unique_ptr<HttpServer>> ServerHandler::_servers;
+bool ServerHandler::_sigintReceived = false;
+
+void	ServerHandler::signalHandler(int signal) 
+{
+	(void)signal;
+	std::cout << "SIGINT received, shutting down servers...\n"; // TODO log sigint received
+	_sigintReceived = true;
+}
 
 ServerHandler::ServerHandler(std::string path) : 
 	_config(ServerConfigData(path)), _fileLogger("test_log.txt"), _consoleLogger(std::cout),
@@ -22,7 +29,6 @@ ServerHandler::ServerHandler(std::string path) :
 	_servers.reserve(_serverCount);
 	_ports.reserve(_serverCount);
 	_pollFds.reserve(_serverCount); // reserves space for ports
-	_running = false;
 
 	std::cout << "Constructor Size of pollfd list: " << _pollFds.capacity() << "\n";
 }
@@ -30,7 +36,7 @@ ServerHandler::ServerHandler(std::string path) :
 ServerHandler::~ServerHandler() 
 {
 	_servers.clear();
-	_pollFds.clear();
+	_pollFds.clear(); 
 
 	std::cout << "Servers closed down\n";
 }
@@ -241,8 +247,10 @@ void	ServerHandler::pollLoop()
 {
 	int	poll_count;
 
+	std::signal(SIGINT, ServerHandler::signalHandler);
+	std::signal(SIGPIPE, SIG_IGN);
 	setPollList();
-	while (_running)
+	while (!_sigintReceived)
 	{
 		if ((poll_count = poll(_pollFds.data(), _pollFds.size(), -1)) == -1)
 			error_and_exit("Poll failed");
@@ -294,6 +302,9 @@ void	ServerHandler::pollLoop()
 			}
 		}
 	}
+	//
+	for (pollfd p : _pollFds)
+		close(p.fd);
 }
 
 void	ServerHandler::handleServerException(int statusCode, size_t& i)
@@ -384,19 +395,10 @@ void	ServerHandler::writeToFd(size_t& i) {
 	}
 }
 
-void	ServerHandler::signalHandler(int signal) 
-{
-	// handle shutdown
-	std::cout << " Ctrl + C signal received, shutting down\n";
-	_servers.clear();
-	exit(signal);
-}
-
 void	ServerHandler::runServers()
 {
-	std::signal(SIGINT, ServerHandler::signalHandler);
-	std::signal(SIGPIPE, SIG_IGN);
-
-	_running = true;
 	pollLoop();
+	_resourceFds.clear();
+	_clients.clear();
+	_servers.clear();
 }


### PR DESCRIPTION
Adds graceful exit on sigint using a static bool for ServerHandler and using that as the control for the poll loop. Makes _servers non-static.

Also adds reset function to ResponseHandler so that _totalBytesWritten can be reset on client reset from ServerHandler.

Todo: kill children on sigint?

Closes #126 