### PR TITLE
Request header parsing

### DIFF
--- a/includes/HttpRequest.hpp
+++ b/includes/HttpRequest.hpp
@@ -5,6 +5,9 @@
 
 struct HttpRequest
 {
+	bool headersReady;
+	bool bodyReady;
+	size_t bodyStart;
 	std::string method;										// "GET", "POST", "DELETE"
 	std::string uri;										// e.g. "/index.html"
 	std::string uriQuery;									// query string portion of the URI

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -8,9 +8,9 @@
 struct Client;
 
 enum ChunkParseState {
-	READ_SIZE,
-	READ_DATA,
-	READ_CRLF
+	SIZE,
+	DATA,
+	CRLF
 };
 
 struct MultipartFormData {
@@ -39,7 +39,7 @@ class RequestHandler
 		void processPost();
 		void processDelete();
 		void readHeaders();
-		void readChunkedRequest();
+		void handleChunkedRequest();
 		bool _isChunked;
 		bool _chunkedBodyStarted;
 		ChunkParseState _chunkState;

--- a/includes/RequestParser.hpp
+++ b/includes/RequestParser.hpp
@@ -17,8 +17,7 @@ class RequestParser
 		static void parseMultipartHeaders(std::map<std::string, std::string>& headerMap, const std::string& headers);
 		static std::string getFilename(const std::string& contentDisposition);
 	public:
-		// Parses raw HTTP request string into an HttpRequest object
-		static bool parseRequest(const std::string& raw_request, HttpRequest& request);
+		static bool parseRequest(const std::string& raw_request, HttpRequest& request);			// Parses raw HTTP request string into an HttpRequest object
 		static std::string parseChunkedBody(const std::string& chunked);						// Function to parse a chunked body
 		static void parseMultipart(const std::string& boundary, const std::string& body, std::vector <MultipartFormData>& parts);
 };

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -18,14 +18,16 @@ void RequestHandler::resetHandler() {
 	_readReady = false;
 	_isChunked = false;
 	_chunkedBodyStarted = false;
-	_chunkState = READ_SIZE;
+	_chunkState = SIZE;
 	_expectedChunkSize = 0;
 	_multipart = false;
 	_partIndex = 0;
 	_parts.clear();
+	_request = nullptr;
 }
 
 void RequestHandler::handleRequest() {
+	_request = std::make_unique<HttpRequest>();
 	if (!_readReady)
 		readRequest();
 	else if (_multipart && ++_partIndex < _parts.size()) {
@@ -46,6 +48,9 @@ void RequestHandler::readHeaders()
 
 	_headersRead = true;
 	_headerPart = _requestString.substr(0, headersEnd + 4);
+	_request->headersReady = true;
+	if (!RequestParser::parseRequest(_headerPart, *_request))
+		throw ServerException(STATUS_BAD_REQUEST);
 
 	std::string headerLower = _headerPart;
 	std::transform(headerLower.begin(), headerLower.end(), headerLower.begin(), ::tolower);
@@ -53,7 +58,7 @@ void RequestHandler::readHeaders()
 		_isChunked = true;
 }
 
-void RequestHandler::readChunkedRequest()
+void RequestHandler::handleChunkedRequest()
 {
 	size_t headersEnd = _requestString.find("\r\n\r\n");
 	if (!_chunkedBodyStarted) {
@@ -66,7 +71,7 @@ void RequestHandler::readChunkedRequest()
 	}
 
 	while (true) {
-		if (_chunkState == READ_SIZE) {
+		if (_chunkState == SIZE) {
 			size_t pos = _chunkBuffer.find("\r\n");
 			if (pos == std::string::npos)
 				return; // need more data
@@ -79,30 +84,31 @@ void RequestHandler::readChunkedRequest()
 
 			if (_expectedChunkSize == 0) {
 				_readReady = true;
+				_request->bodyReady = true;
 				processRequest();
 				return;
 			}
-			_chunkState = READ_DATA;
+			_chunkState = DATA;
 		}
 
-		if (_chunkState == READ_DATA) {
+		if (_chunkState == DATA) {
 			if (_chunkBuffer.size() < _expectedChunkSize)
 				return;
 
 			_decodedBody += _chunkBuffer.substr(0, _expectedChunkSize);
 			_chunkBuffer.erase(0, _expectedChunkSize);
 
-			_chunkState = READ_CRLF;
+			_chunkState = CRLF;
 		}
 
-		if (_chunkState == READ_CRLF) {
+		if (_chunkState == CRLF) {
 			if (_chunkBuffer.size() < 2)
 				return; // wait for trailing line break
 			if (_chunkBuffer.substr(0, 2) != "\r\n")
 				throw ServerException(STATUS_BAD_REQUEST);
 
 			_chunkBuffer.erase(0, 2);
-			_chunkState = READ_SIZE;
+			_chunkState = SIZE;
 		}
 	}
 }
@@ -118,6 +124,8 @@ void RequestHandler::readRequest() {
 		throw ServerException(STATUS_DISCONNECTED);
 	if (receivedBytes == 0 && _isChunked && !_readReady)
 		throw ServerException(STATUS_BAD_REQUEST);
+	if (receivedBytes <= 0)
+		throw ServerException(STATUS_INTERNAL_ERROR);
 
 	_requestString.append(buf, receivedBytes);
 
@@ -125,15 +133,14 @@ void RequestHandler::readRequest() {
 		readHeaders();
 
 	if (_isChunked) {
-		if (!_request)
-			_request = std::make_unique<HttpRequest>();
-		readChunkedRequest();
+		handleChunkedRequest();
 		return;
 	}
 
 	if (receivedBytes < BUFFER_SIZE) {
 		_readReady = true;
 		std::cout << "Client " << _client.fd << " complete request received!\n";
+		_request->bodyReady = true;
 		processRequest();
 	}
 }
@@ -143,10 +150,14 @@ void RequestHandler::processRequest() {
 	if (!_request)
 		_request = std::make_unique<HttpRequest>();
 
-	if (_isChunked)
-		RequestParser::parseRequest(_headerPart + _decodedBody, *_request.get());
-	else
-		RequestParser::parseRequest(_requestString, *_request.get());
+	if (_isChunked) {
+		if (!RequestParser::parseRequest(_headerPart + _decodedBody, *_request.get()))
+			throw ServerException(STATUS_BAD_REQUEST);
+	}
+	else {
+		if (!RequestParser::parseRequest(_headerPart + _decodedBody, *_request.get()))
+			throw ServerException(STATUS_BAD_REQUEST);
+	}
 
 	// TODO Check redirects
 

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -48,9 +48,11 @@ void RequestHandler::readHeaders()
 
 	_headersRead = true;
 	_headerPart = _requestString.substr(0, headersEnd + 4);
-	_request->headersReady = true;
-	if (!RequestParser::parseRequest(_headerPart, *_request))
-		throw ServerException(STATUS_BAD_REQUEST);
+	if (_headersRead)
+	{
+		if (!RequestParser::parseRequest(_headerPart, *_request))
+			throw ServerException(STATUS_BAD_REQUEST);
+	}
 
 	std::string headerLower = _headerPart;
 	std::transform(headerLower.begin(), headerLower.end(), headerLower.begin(), ::tolower);
@@ -84,7 +86,6 @@ void RequestHandler::handleChunkedRequest()
 
 			if (_expectedChunkSize == 0) {
 				_readReady = true;
-				_request->bodyReady = true;
 				processRequest();
 				return;
 			}
@@ -140,7 +141,6 @@ void RequestHandler::readRequest() {
 	if (receivedBytes < BUFFER_SIZE) {
 		_readReady = true;
 		std::cout << "Client " << _client.fd << " complete request received!\n";
-		_request->bodyReady = true;
 		processRequest();
 	}
 }

--- a/sources/RequestParser.cpp
+++ b/sources/RequestParser.cpp
@@ -145,7 +145,7 @@ void RequestParser::parseBody(const std::string& body_part, HttpRequest& request
 // Parses the entire HTTP request string into the HttpRequest object
 bool RequestParser::parseRequest(const std::string& raw_request, HttpRequest& request)
 {
-	if (request.headersReady)
+	if (!request.headersReady)
 	{
 		// Split the raw request into request line, headers, and body
 		size_t pos = raw_request.find("\r\n");  // Find the first line break (request line)
@@ -166,9 +166,10 @@ bool RequestParser::parseRequest(const std::string& raw_request, HttpRequest& re
 		std::string headers_part = raw_request.substr(headers_start, headers_end - headers_start);
 		if (!parseHeaders(headers_part, request))
 			return false;
+		request.headersReady = true;
 	}
 
-	if (request.bodyReady)
+	else
 	{
 		// The body is the remaining part after headers
 		if (request.bodyStart < raw_request.size())
@@ -176,6 +177,7 @@ bool RequestParser::parseRequest(const std::string& raw_request, HttpRequest& re
 			std::string body_part = raw_request.substr(request.bodyStart);
 			parseBody(body_part, request);
 		}
+		request.bodyReady = true;
 	}
 	return true;
 }

--- a/sources/RequestParser.cpp
+++ b/sources/RequestParser.cpp
@@ -101,8 +101,14 @@ std::string RequestParser::parseChunkedBody(const std::string& chunked)
 		std::istringstream sizeStream(sizeLine);
 		sizeStream >> std::hex >> chunkSize;
 
-		if (chunkSize == 0)
+		if (chunkSize == 0) {
+			char cr, lf;
+			stream.get(cr);
+			stream.get(lf);
+			if (cr != '\r' || lf != '\n')
+				throw ServerException(STATUS_BAD_REQUEST);
 			break;
+		}
 
 		std::string chunk(chunkSize, '\0');
 		stream.read(&chunk[0], chunkSize);

--- a/sources/RequestParser.cpp
+++ b/sources/RequestParser.cpp
@@ -145,30 +145,37 @@ void RequestParser::parseBody(const std::string& body_part, HttpRequest& request
 // Parses the entire HTTP request string into the HttpRequest object
 bool RequestParser::parseRequest(const std::string& raw_request, HttpRequest& request)
 {
-	// Split the raw request into request line, headers, and body
-	size_t pos = raw_request.find("\r\n");  // Find the first line break (request line)
-	if (pos == std::string::npos) return false;
-
-	// Parse the request line
-	std::string request_line = raw_request.substr(0, pos);
-	if (!parseRequestLine(request_line, request))
-		return false;
-
-	// Find the headers section (between request line and body)
-	size_t headers_start = pos + 2;  // Skip the \r\n
-	size_t headers_end = raw_request.find("\r\n\r\n", headers_start);
-	if (headers_end == std::string::npos) return false;
-
-	std::string headers_part = raw_request.substr(headers_start, headers_end - headers_start);
-	if (!parseHeaders(headers_part, request))
-		return false;
-
-	// The body is the remaining part after headers
-	size_t body_start = headers_end + 4;  // Skip the \r\n\r\n
-	if (body_start < raw_request.size())
+	if (request.headersReady)
 	{
-		std::string body_part = raw_request.substr(body_start);
-		parseBody(body_part, request);
+		// Split the raw request into request line, headers, and body
+		size_t pos = raw_request.find("\r\n");  // Find the first line break (request line)
+		if (pos == std::string::npos) return false;
+
+		// Parse the request line
+		std::string request_line = raw_request.substr(0, pos);
+		if (!parseRequestLine(request_line, request))
+			return false;
+
+		// Find the headers section (between request line and body)
+		size_t headers_start = pos + 2;  // Skip the \r\n
+		size_t headers_end = raw_request.find("\r\n\r\n", headers_start);
+		if (headers_end == std::string::npos) return false;
+
+		request.bodyStart = headers_end + 4;
+
+		std::string headers_part = raw_request.substr(headers_start, headers_end - headers_start);
+		if (!parseHeaders(headers_part, request))
+			return false;
+	}
+
+	if (request.bodyReady)
+	{
+		// The body is the remaining part after headers
+		if (request.bodyStart < raw_request.size())
+		{
+			std::string body_part = raw_request.substr(request.bodyStart);
+			parseBody(body_part, request);
+		}
 	}
 	return true;
 }

--- a/testing/chunktest.sh
+++ b/testing/chunktest.sh
@@ -6,3 +6,5 @@ curl -v -X POST http://localhost:8080/uploads/chunktest.txt \
   -H "Transfer-Encoding: chunked" \
   -H "Content-Type: text/plain" \
   --data-binary @chunked_input.txt
+
+rm chunked_input.txt

--- a/testing/chunktest.sh
+++ b/testing/chunktest.sh
@@ -1,6 +1,6 @@
 #!bin/bash
 
-printf "5\r\nHello\r\n5\r\nWorld\r\n0\r\n\r\n" > chunked_input.txt
+printf "5\r\nHillo\r\n5\r\nWorld\r\n0\r\n\r\n" > chunked_input.txt
 
 curl -v -X POST http://localhost:8080/uploads/chunktest.txt \
   -H "Transfer-Encoding: chunked" \

--- a/testing/chunktest.sh
+++ b/testing/chunktest.sh
@@ -1,6 +1,6 @@
 #!bin/bash
 
-printf "5\r\nHillo\r\n5\r\nWorld\r\n0\r\n\r\n" > chunked_input.txt
+printf "5\r\nHello\r\n5\r\nWorld\r\n0\r\n\r\n" > chunked_input.txt
 
 curl -v -X POST http://localhost:8080/uploads/chunktest.txt \
   -H "Transfer-Encoding: chunked" \


### PR DESCRIPTION
Request handler now: 
 - initializes the request struct before reading anything.
 - Parses the request line and headers before reading the body.
 - Throws a bad request in case chunked body is malformed.