### PR TITLE
Fix/multipart and post handling

### DIFF
--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -27,7 +27,8 @@ void RequestHandler::resetHandler() {
 }
 
 void RequestHandler::handleRequest() {
-	_request = std::make_unique<HttpRequest>();
+	if (!_request)
+		_request = std::make_unique<HttpRequest>();
 	if (!_readReady)
 		readRequest();
 	else if (_multipart && ++_partIndex < _parts.size()) {

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -123,22 +123,15 @@ void RequestHandler::readRequest() {
 		throw ServerException(STATUS_RECV_ERROR);
 	if (receivedBytes == 0)
 		throw ServerException(STATUS_DISCONNECTED);
-	if (receivedBytes == 0 && _isChunked && !_readReady)
-		throw ServerException(STATUS_BAD_REQUEST);
-	if (receivedBytes <= 0)
-		throw ServerException(STATUS_INTERNAL_ERROR);
 
 	_requestString.append(buf, receivedBytes);
 
 	if (!_headersRead)
 		readHeaders();
 
-	if (_isChunked) {
+	if (_isChunked)
 		handleChunkedRequest();
-		return;
-	}
-
-	if (receivedBytes < BUFFER_SIZE) {
+	else if (receivedBytes < BUFFER_SIZE) {
 		_readReady = true;
 		std::cout << "Client " << _client.fd << " complete request received!\n";
 		processRequest();

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -49,11 +49,8 @@ void RequestHandler::readHeaders()
 
 	_headersRead = true;
 	_headerPart = _requestString.substr(0, headersEnd + 4);
-	if (_headersRead)
-	{
-		if (!RequestParser::parseRequest(_headerPart, *_request))
-			throw ServerException(STATUS_BAD_REQUEST);
-	}
+	if (!RequestParser::parseRequest(_headerPart, *_request))
+		throw ServerException(STATUS_BAD_REQUEST);
 
 	std::string headerLower = _headerPart;
 	std::transform(headerLower.begin(), headerLower.end(), headerLower.begin(), ::tolower);
@@ -141,9 +138,6 @@ void RequestHandler::readRequest() {
 
 
 void RequestHandler::processRequest() {
-	if (!_request)
-		_request = std::make_unique<HttpRequest>();
-
 	if (_isChunked) {
 		if (!RequestParser::parseRequest(_headerPart + _decodedBody, *_request.get()))
 			throw ServerException(STATUS_BAD_REQUEST);

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -208,9 +208,11 @@ void RequestHandler::processPost() {
 		processMultipartForm();
 	// if ((*itContentTypeHeader).second != FileHandler::getMIMEType(_request->uriPath))
 	// 	throw ServerException(STATUS_BAD_REQUEST);
-	_client.resourceOutString = _request->body;
-	_client.resourcePath = ServerConfigData::getRoot(*_client.serverConfig, _request->uriPath) + _request->uriPath;
-	FileHandler::openForWrite( _client.resourceWriteFd, _client.resourcePath);
+	else {
+		_client.resourceOutString = _request->body;
+		_client.resourcePath = ServerConfigData::getRoot(*_client.serverConfig, _request->uriPath) + _request->uriPath;
+		FileHandler::openForWrite( _client.resourceWriteFd, _client.resourcePath);
+	}
 }
 
 void RequestHandler::processDelete() {
@@ -230,6 +232,7 @@ bool RequestHandler::isMultipartForm() const {
 }
 
 void RequestHandler::processMultipartForm() {
+	_multipart = true;
 	std::string type = _request->headers.at("Content-Type");
 	std::string prefix = "multipart/form-data; boundary=";
 	if (type.find(prefix) == std::string::npos)

--- a/sources/RequestParser.cpp
+++ b/sources/RequestParser.cpp
@@ -222,7 +222,7 @@ void RequestParser::parseMultipart(const std::string& boundary, const std::strin
 	std::string delimiter = "--" + boundary;
 	size_t pos = 0, next;
 	while ((next = body.find(delimiter, pos)) != std::string::npos) {
-		size_t end = body.find(delimiter, next + delimiter.length());
+		size_t end = body.find("\r\n" + delimiter, next + delimiter.length());
 		if (end == std::string::npos)
 			break;
 		std::string partString = body.substr(next + delimiter.length(), end - next - delimiter.length());

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -90,9 +90,10 @@ void ResponseHandler::formGET() {
 void ResponseHandler::formPOST() {
 	addStatus();
 	addHeader("Date", getTimeStamp());
-	addHeader("Content-Type", "application/json");
-	addHeader("Location", _client.requestHandler->getUri());
-	addBody("{\n  \"status\": \"success\",\n  \"message\": \"Resouce successfully created\",\n  \"resource_id\": " + _client.requestHandler->getUri() + "\n}");
+	// addHeader("Content-Type", "application/json");
+	// addHeader("Location", _client.requestHandler->getUri());
+	// addBody("{\n  \"status\": \"success\",\n  \"message\": \"Resouce successfully created\",\n  \"resource_id\": " + _client.requestHandler->getUri() + "\n}");
+	addBody("");
 }
 
 void ResponseHandler::formDELETE() {

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -360,6 +360,7 @@ void	ServerHandler::readFromFd(size_t& i) {
 			client.requestReady = true;
 			std::cout << "Client " << client.fd << " resource read from fd " << _pollFds[i].fd << "\n";
 			removeResourceFd(client.resourceReadFd);
+			client.resourceReadFd = -1;
 		}
 		else
 		{
@@ -382,11 +383,12 @@ void	ServerHandler::writeToFd(size_t& i) {
 		client.resourceBytesWritten += bytesWritten;
 		if (client.resourceBytesWritten == client.resourceOutString.size())
 		{
-			client.requestReady = true;
 			client.responseCode = STATUS_CREATED;
 			std::cout << "Client " << client.fd << " resource written to fd " << _pollFds[i].fd << "\n";
 			removeResourceFd(client.resourceWriteFd);
+			client.resourceWriteFd = -1;
 			client.requestHandler->handleRequest();
+			addResourceFd(client);
 		}
 		else
 		{

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -312,7 +312,6 @@ void	ServerHandler::handleServerException(int statusCode, size_t& i)
 	// Set client from either _clients struct or from requestFds struct.
 	Client& client = (_clients.find(_pollFds[i].fd) != _clients.end()) ? *_clients[_pollFds[i].fd].get() : *_resourceFds.at(_pollFds[i].fd);
 	if (statusCode == STATUS_DISCONNECTED || statusCode == STATUS_RECV_ERROR || statusCode == STATUS_SEND_ERROR) {
-		// TODO log error
 		closeConnection(i);
 		return;
 	}
@@ -348,24 +347,16 @@ void	ServerHandler::readFromFd(size_t& i) {
 	char buf[BUFFER_SIZE] = {};
 
 	bytesRead = read(client.resourceReadFd, buf, BUFFER_SIZE);
-	if (bytesRead <= 0) {
+	if (bytesRead <= 0)
 		throw ServerException(STATUS_INTERNAL_ERROR);
-	}
-	else {
-		client.resourceInString.append(buf, bytesRead);
-		client.resourceBytesRead += bytesRead;
-		// std::cout << "Total bytes read: " << client.resourceBytesRead << "\n";
-		if (bytesRead < BUFFER_SIZE)
-		{
-			client.requestReady = true;
-			std::cout << "Client " << client.fd << " resource read from fd " << _pollFds[i].fd << "\n";
-			removeResourceFd(client.resourceReadFd);
-			client.resourceReadFd = -1;
-		}
-		else
-		{
-			std::cout << "Client " << client.fd << " read " << bytesRead << " bytes from fd " << _pollFds[i].fd << ", continuing...\n";
-		}
+	client.resourceInString.append(buf, bytesRead);
+	client.resourceBytesRead += bytesRead;
+	if (bytesRead < BUFFER_SIZE)
+	{
+		client.requestReady = true;
+		std::cout << "Client " << client.fd << " resource read from fd " << _pollFds[i].fd << "\n";
+		removeResourceFd(client.resourceReadFd);
+		client.resourceReadFd = -1;
 	}
 }
 
@@ -377,23 +368,18 @@ void	ServerHandler::writeToFd(size_t& i) {
 		bytesToWrite = BUFFER_SIZE;
 
 	bytesWritten = write(client.resourceWriteFd, client.resourceOutString.c_str() + client.resourceBytesWritten, bytesToWrite);
-	if (bytesWritten <= 0)
+	if (bytesWritten <= 0 && bytesToWrite != 0)
 		throw ServerException(STATUS_INTERNAL_ERROR);
-	else {
-		client.resourceBytesWritten += bytesWritten;
-		if (client.resourceBytesWritten == client.resourceOutString.size())
-		{
-			client.responseCode = STATUS_CREATED;
-			std::cout << "Client " << client.fd << " resource written to fd " << _pollFds[i].fd << "\n";
-			removeResourceFd(client.resourceWriteFd);
-			client.resourceWriteFd = -1;
-			client.requestHandler->handleRequest();
-			addResourceFd(client);
-		}
-		else
-		{
-			std::cout << "Client " << client.fd << " wrote " << bytesWritten << " bytes to fd " << _pollFds[i].fd << ", continuing...\n";
-		}
+	client.resourceBytesWritten += bytesWritten;
+	if (client.resourceBytesWritten == client.resourceOutString.size())
+	{
+		client.responseCode = STATUS_CREATED;
+		std::cout << "Client " << client.fd << " resource written to fd " << _pollFds[i].fd << "\n";
+		removeResourceFd(client.resourceWriteFd);
+		client.resourceWriteFd = -1;
+		client.resourceBytesWritten = 0;
+		client.requestHandler->handleRequest();
+		addResourceFd(client);
 	}
 }
 

--- a/var/www/html/upload.html
+++ b/var/www/html/upload.html
@@ -10,7 +10,7 @@
 	<p>Choose a file to upload.</p>
 	<form action="/uploads" method="POST" enctype="multipart/form-data">
 		<label for="file">Choose file:</label><br>
-		<input type="file" id="file" name="file" required><br><br>
+		<input type="file" id="file" name="file" required multiple><br><br>
 		<button type="submit">Upload</button>
 	</form>
 


### PR DESCRIPTION
Fixes multipart post handling and removes redundant conditionals from refactored readRequest handling.

Read refactor caused issues with body parsing in non-chunked requests: bodies are always empty.