### PR TITLE
fixes parsing of non-chunked requests

### DIFF
--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -147,7 +147,7 @@ void RequestHandler::processRequest() {
 			throw ServerException(STATUS_BAD_REQUEST);
 	}
 	else {
-		if (!RequestParser::parseRequest(_headerPart + _decodedBody, *_request.get()))
+		if (!RequestParser::parseRequest(_requestString, *_request.get()))
 			throw ServerException(STATUS_BAD_REQUEST);
 	}
 

--- a/testing/chunktest.sh
+++ b/testing/chunktest.sh
@@ -1,6 +1,6 @@
 #!bin/bash
 
-printf "5\r\nHello\r\n5\r\nWorld\r\n0\r\n\r\n" > chunked_input.txt
+printf "5\r\nHillo\r\n5\r\nWorld\r\n0\r\n\r\n" > chunked_input.txt
 
 curl -v -X POST http://localhost:8080/uploads/chunktest.txt \
   -H "Transfer-Encoding: chunked" \

--- a/testing/non-chunktest.sh
+++ b/testing/non-chunktest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo -n "HulloWorld" > post_input.txt
+
+curl -v -X POST http://localhost:8080/uploads/posttest.txt \
+  -H "Content-Type: text/plain" \
+  --data-binary @post_input.txt
+
+rm post_input.txt


### PR DESCRIPTION
Now correctly passing _requestString (instead of header part + decoded body) to the request parser if request is not chunked.
closes #136 