### PR TITLE
Fix/request read limiter

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -8,6 +8,9 @@ server {
   server_name www.localhost localhost;
   root var/www/html;
 
+  # Client body size limit
+  client_max_body_size 10M;
+  
   error_page 404 /errors/404.html;
 
   location / {
@@ -67,8 +70,6 @@ server {
   server_name www.localhost localhost;
   root var/www/html;
 
-  # Client body size limit
-  client_max_body_size 10M;
   error_page 404 /errors/404.html;
   error_page 500 /errors/500.html;
 

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -55,7 +55,6 @@ class RequestHandler
 		void handleRequest();
 
 		const HttpRequest& getRequest() const;
-		// Not sure if the getters below are needed, as most of the work will be done with the whole struct from above
 		const std::string& getMethod() const;
 		const std::string& getUri() const;
 		const std::string& getUriQuery() const;
@@ -63,4 +62,5 @@ class RequestHandler
 		const std::string& getHttpVersion() const;
 		const std::string& getBody() const;
 		const std::vector <MultipartFormData>& getParts() const;
+		bool getReadReady() const;
 };

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -38,7 +38,7 @@ class RequestHandler
 		void processGet();
 		void processPost();
 		void processDelete();
-		void readHeaders();
+		void handleHeaders();
 		void handleChunkedRequest();
 		bool _isChunked;
 		bool _chunkedBodyStarted;

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -31,7 +31,8 @@ class RequestHandler
 		bool _headersRead;
 		bool _readReady;
 		bool _multipart;
-		size_t	_partIndex;
+		size_t _expectedContentLength;
+		size_t _partIndex;
 		std::vector <MultipartFormData> _parts;
 		void readRequest();
 		void processRequest();
@@ -40,6 +41,7 @@ class RequestHandler
 		void processDelete();
 		void handleHeaders();
 		void handleChunkedRequest();
+		void setContentLength();
 		bool _isChunked;
 		bool _chunkedBodyStarted;
 		ChunkParseState _chunkState;

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -45,7 +45,7 @@ void RequestHandler::handleRequest() {
 	
 }
 
-void RequestHandler::readHeaders()
+void RequestHandler::handleHeaders()
 {
 	size_t headersEnd = _requestString.find("\r\n\r\n");
 	if (headersEnd == std::string::npos)
@@ -125,12 +125,9 @@ void RequestHandler::readRequest() {
 		throw ServerException(STATUS_RECV_ERROR);
 	if (receivedBytes == 0)
 		throw ServerException(STATUS_DISCONNECTED);
-
 	_requestString.append(buf, receivedBytes);
-
 	if (!_headersRead)
-		readHeaders();
-
+		handleHeaders();
 	if (_isChunked)
 		handleChunkedRequest();
 	else if (receivedBytes < BUFFER_SIZE) {

--- a/sources/RequestParser.cpp
+++ b/sources/RequestParser.cpp
@@ -34,9 +34,6 @@ bool RequestParser::parseRequestLine(const std::string& request_line, HttpReques
 	for (size_t i = 0; i < request.method.length(); ++i)
 		request.method[i] = std::toupper(request.method[i]);
 
-	if (request.method != "GET" && request.method != "POST" && request.method != "DELETE")
-		return false;  // Unsupported HTTP method
-
 	request.uriPath = request.uri;
 	size_t delimiter = request.uri.find("?");
 	if (delimiter != std::string::npos)

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -164,6 +164,8 @@ void ResponseHandler::formDirectoryListing() {
 void ResponseHandler::formErrorPage() {
 	addStatus();
 	addHeader("Date", getTimeStamp());
+	if (!_client.keep_alive)
+		addHeader("Connection", "close");
 	addHeader("Content-Type", "text/html");
 	if (_client.resourceInString.empty()) {
 		std::string code = std::to_string(_client.responseCode);

--- a/sources/ServerException.cpp
+++ b/sources/ServerException.cpp
@@ -41,7 +41,7 @@ const char* ServerException::statusMessage(int statusCode) {
 		case 411:
 			return "Length Required";
 		case 413:
-			return "Request Too Large";
+			return "Content Too Large";
 		case 414:
 			return "Request-URI Too Long";
 		case 415:

--- a/var/www/html/errors/413.html
+++ b/var/www/html/errors/413.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>413 Payload Too Large</title>
+<head><meta charset="UTF-8"><title>413 Content Too Large</title>
 <style>body { font-family: sans-serif; text-align: center; padding: 50px; } h1 { font-size: 48px; color: #cc0000; }</style></head>
 <body>
   <h1>413</h1>
-  <p>The request payload is too large to process.</p>
+  <p>The request content is too large to process.</p>
 </body>
 </html>


### PR DESCRIPTION
Adds a plethora of checks to ensure incoming request complies with server max request size, contains necessary content-length header and adheres to it.

Only persisting issue is that if reading is stopped with a request that is too large, the error page does not seem to be received by client before connection is closed. :shrug: 