### PR TITLE
Fix/client last activity timestamp

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -15,7 +15,7 @@ class ResponseHandler;
 struct Client {
 	const Config*						serverConfig;
 	int									fd;
-	std::time_t							lastRequest;
+	std::time_t							lastActivity;
 	std::unique_ptr<ResponseHandler>	responseHandler;
 	std::unique_ptr<RequestHandler>		requestHandler;
 	std::string							resourcePath;

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -55,6 +55,7 @@ void RequestHandler::readRequest() {
 		throw ServerException(STATUS_RECV_ERROR);
 	if (receivedBytes == 0)
 		throw ServerException(STATUS_DISCONNECTED);
+	_client.lastActivity = std::time(nullptr);
 	_requestString.append(buf, receivedBytes);
 	handleHeaders();
 	if (!_headersRead)

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -113,7 +113,7 @@ bool ServerHandler::checkTimeout(const Client& client)
 {
 	const std::time_t now = std::time(nullptr);
 	const int timeout = (client.serverConfig->timeout != 0) ? client.serverConfig->timeout : 7;
-	if (now - client.lastRequest > timeout)
+	if (now - client.lastActivity > timeout)
 		return false;
 	return true;
 }
@@ -261,7 +261,7 @@ void ServerHandler::addConnection(size_t& i) {
 		client.keepAlive = false;
 		client.requestHandler = std::make_unique<RequestHandler>(*_clients[clientFd].get());
 		client.responseHandler = std::make_unique<ResponseHandler>(*_clients[clientFd].get());
-		client.lastRequest = std::time(nullptr);
+		client.lastActivity = std::time(nullptr);
 		resetClient(client);
 		std::cout << "Client connected to server " << _servers.at(i)->getServerConfig()->port << " with fd " << client.fd << "\n";
 	} catch (const ServerException& e) {
@@ -296,7 +296,6 @@ void	ServerHandler::pollLoop()
 					{
 						Client& client = *_clients[_pollFds[i].fd].get();
 						client.requestHandler->handleRequest();
-						client.lastRequest = std::time(nullptr);
 						if (client.cgiRequested)
 							_CGIHandler.handleCGI(client);
 						addResourceFd(client);


### PR DESCRIPTION
Client lastRequest timestamp was set in poll loop and often triggered when the client had in fact not done anything. Renamed to lastActivity and moved setting to readRequest, where it is set to now if recv reads something. Fixes issue with siege leaving clients in limbo on premature quit.