### PR TITLE
Fix/post request problems

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -12,6 +12,14 @@ struct Config;
 class RequestHandler;
 class ResponseHandler;
 
+enum ConnectionState
+{
+	ACTIVE,
+	DRAIN,
+	DRAINED,
+	CLOSE
+};
+
 struct Client {
 	const Config*						serverConfig;
 	int									fd;
@@ -27,11 +35,11 @@ struct Client {
 	size_t								resourceBytesWritten;
 	int									responseSent;
 	int									responseCode;
+	ConnectionState						connectionState;
 	bool								keepAlive;
 	bool								cgiRequested;
 	bool								directoryListing;
 	bool								requestReady;
 	bool								responseReady;
-	bool								closeAnyway;
 	int									cgiStatus;
 };

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -47,7 +47,6 @@ class RequestHandler
 		bool _chunkedBodyStarted;
 		ChunkParseState _chunkState;
 		size_t _expectedChunkSize = 0;
-		bool isMultipartForm() const;
 		void processMultipartForm();
 	public:
 		RequestHandler(Client& client);

--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -32,6 +32,7 @@ class RequestHandler
 		bool _readReady;
 		bool _multipart;
 		size_t _expectedContentLength;
+		size_t _totalReceivedLength;
 		size_t _partIndex;
 		std::vector <MultipartFormData> _parts;
 		void readRequest();

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -43,7 +43,7 @@ void ResponseHandler::sendResponse() {
 Adds status line to response
 */
 void ResponseHandler::addStatus() {
-	if (_client.connectionState != DRAIN || _client.connectionState != DRAINED)
+	if (_client.connectionState != DRAIN && _client.connectionState != DRAINED)
 		_response->response = _client.requestHandler->getHttpVersion() + " " + std::to_string(_client.responseCode) + " " + ServerException::statusMessage(_client.responseCode) + "\r\n";
 	else
 		_response->response = "HTTP/1.1 " + std::to_string(_client.responseCode) + " " + ServerException::statusMessage(_client.responseCode) + "\r\n";

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -43,7 +43,10 @@ void ResponseHandler::sendResponse() {
 Adds status line to response
 */
 void ResponseHandler::addStatus() {
-	_response->response = _client.requestHandler->getHttpVersion() + " " + std::to_string(_client.responseCode) + " " + ServerException::statusMessage(_client.responseCode) + "\r\n";
+	if (_client.connectionState != DRAIN || _client.connectionState != DRAINED)
+		_response->response = _client.requestHandler->getHttpVersion() + " " + std::to_string(_client.responseCode) + " " + ServerException::statusMessage(_client.responseCode) + "\r\n";
+	else
+		_response->response = "HTTP/1.1 " + std::to_string(_client.responseCode) + " " + ServerException::statusMessage(_client.responseCode) + "\r\n";
 }
 
 /*

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -118,7 +118,7 @@ void ServerHandler::checkClients()
 				Logger::log(Logger::OK, "Client " + std::to_string(client.fd) + " timed out, disconnecting");
 				closeConnection(i);
 			}
-			if (client.connectionState != DRAIN && client.responseSent && !client.keepAlive)
+			else if (client.connectionState != DRAIN && client.responseSent && !client.keepAlive)
 			{
 				Logger::log(Logger::OK, "Client " + std::to_string(client.fd) + " connection disconnected by server");
 				closeConnection(i);


### PR DESCRIPTION
Implements draining of requests that are deemed erroneous before entire request is received. Connections are closed only after incoming request has been drained and proper response has been sent.

Closes #152 