### PR TITLE
Fix/mime type checking

### DIFF
--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -49,6 +49,9 @@ class RequestHandler
 		ChunkParseState _chunkState;
 		size_t _expectedChunkSize = 0;
 		void processMultipartForm();
+		void checkContentType() const;
+		void checkAcceptType() const;
+		void checkContentLength() const;
 	public:
 		RequestHandler(Client& client);
 		~RequestHandler();

--- a/sources/FileHandler.cpp
+++ b/sources/FileHandler.cpp
@@ -36,7 +36,7 @@ std::string FileHandler::getMIMEType(const std::string& filePath) {
 	std::string extension = filePath.substr(extensionStart);
 	
 	// Defines MIME types, can be added to
-		std::unordered_map<std::string, std::string> types = {
+	std::unordered_map<std::string, std::string> types = {
 		{".html", "text/html"},
 		{".htm", "text/html"},
 		{".css", "text/css"},

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -248,11 +248,8 @@ void RequestHandler::processGet() {
 		else
 			throw ServerException(STATUS_FORBIDDEN);
 	}
-	// Check if request has Accept header and that requested resource matches said content type (TODO: add default "*/*")
-	// auto itAcceptHeader = _request->headers.find("Accept");
-	// if (itAcceptHeader != _request->headers.end() && (*itAcceptHeader).second.find(FileHandler::getMIMEType(_request->uriPath)) == std::string::npos)
-	// 	throw ServerException(STATUS_NOT_ACCEPTABLE);
 	_client.resourcePath = ServerConfigData::getRoot(*_client.serverConfig, path) + path;
+	checkAcceptType();
 	FileHandler::openForRead(_client.resourceReadFd, _client.resourcePath);
 }
 
@@ -263,8 +260,6 @@ void RequestHandler::processPost() {
 		throw ServerException(STATUS_BAD_REQUEST);
 	if (it->second.find("multipart/form-data") == 0)
 		processMultipartForm();
-	// if ((*itContentTypeHeader).second != FileHandler::getMIMEType(_request->uriPath))
-	// 	throw ServerException(STATUS_BAD_REQUEST);
 	else {
 		_client.resourceOutString = _request->body;
 		_client.resourcePath = ServerConfigData::getRoot(*_client.serverConfig, _request->uriPath) + _request->uriPath;
@@ -308,7 +303,9 @@ void RequestHandler::checkContentType() const {
 }
 
 void RequestHandler::checkAcceptType() const {
-	
+	auto it = _request->headers.find("Accept");
+	if (it == _request->headers.end() && it->second.find(FileHandler::getMIMEType(_client.resourcePath)) == std::string::npos)
+		throw ServerException(STATUS_NOT_ACCEPTABLE);
 }
 
 void RequestHandler::checkContentLength() const {

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -306,7 +306,11 @@ void RequestHandler::checkContentType() const {
 
 void RequestHandler::checkAcceptType() const {
 	auto it = _request->headers.find("Accept");
-	if (it == _request->headers.end() && it->second.find(FileHandler::getMIMEType(_client.resourcePath)) == std::string::npos)
+	if (it == _request->headers.end() || it->second.find("*/*") != std::string::npos)
+		return;
+	std::string requestedResourceType = FileHandler::getMIMEType(_client.resourcePath);
+	std::string requestedType = requestedResourceType.substr(0, requestedResourceType.find("/"));
+	if (it->second.find(requestedResourceType) == std::string::npos && it->second.find(requestedType + "/*") == std::string::npos)
 		throw ServerException(STATUS_NOT_ACCEPTABLE);
 }
 

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -145,7 +145,7 @@ void ServerHandler::checkClients()
 				Logger::log(Logger::OK, "Client " + std::to_string(client.fd) + " connection disconnected by client");
 				closeConnection(i);
 			}
-			else if (client.responseSent)
+			else if (client.connectionState != DRAIN && client.responseSent)
 			{
 				_CGIHandler.cleanupCGI(client);
 				resetClient(client);
@@ -380,6 +380,7 @@ void	ServerHandler::handleServerException(int statusCode, size_t& i)
 	client.requestReady = false;
 	client.responseReady = false;
 	client.resourceOutString = "";
+	client.cgiStatus = -1;
 	if (client.resourceReadFd != -1) {
 		removeResourceFd(client.resourceReadFd);
 		client.resourceReadFd = -1;
@@ -397,8 +398,6 @@ void	ServerHandler::handleServerException(int statusCode, size_t& i)
 	}
 	else
 		client.requestReady = true;
-
-	client.cgiStatus = -1;
 }
 
 void	ServerHandler::readFromFd(size_t& i) {


### PR DESCRIPTION
Reimplements checking that the MIME type of POST request files complies with provided Content-Type header. Also adds a check that for GET requests the requested resource matches any Accept headers from the request, otherwise sends a 406.

Fixes #165 