### PR TITLE
Reports on an incoming request when there is actually something incoming

### DIFF
--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -32,10 +32,7 @@ void RequestHandler::resetHandler() {
 
 void RequestHandler::handleRequest() {
 	if (!_request)
-	{
 		_request = std::make_unique<HttpRequest>();
-		Logger::log(Logger::OK, "Client " + std::to_string(_client.fd) + " request incoming");
-	}
 	if (!_readReady)
 		readRequest();
 	else if (_multipart && ++_partIndex < _parts.size()) {
@@ -62,6 +59,8 @@ void RequestHandler::readRequest() {
 	}
 	if (receivedBytes == 0)
 		throw ServerException(STATUS_DISCONNECTED);
+	if (_totalReceivedLength == 0)
+		Logger::log(Logger::OK, "Client " + std::to_string(_client.fd) + " request incoming");
 	_client.lastActivity = std::time(nullptr);
 	_totalReceivedLength += receivedBytes;
 	if (_client.connectionState == DRAIN)


### PR DESCRIPTION
Moves "Client N request incoming" to trigger only, when an actual request is coming in.

Closes #172 

Found out more about these automatic connections. They are related to prefetching, which can also be turned off in the browser confic settings. https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections#w_prefetching