### PR TITLE
Prevent client timeouts during server processing

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -15,6 +15,7 @@ class ResponseHandler;
 enum ConnectionState
 {
 	ACTIVE,
+	PROCESSING,
 	DRAIN,
 	DRAINED,
 	CLOSE

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -192,6 +192,7 @@ void RequestHandler::processRequest() {
 	}
 
 	Logger::log(Logger::OK, "Client " + std::to_string(_client.fd) + " request received: " + _request->method + " " + _request->uri);
+	_client.connectionState = PROCESSING;
 
 	auto it = _request->headers.find("Connection");
 	if (it != _request->headers.end() && it->second == "close")

--- a/sources/ResponseHandler.cpp
+++ b/sources/ResponseHandler.cpp
@@ -37,6 +37,7 @@ void ResponseHandler::sendResponse() {
 	{
 		Logger::log(Logger::OK, "Client " + std::to_string(_client.fd) + " response sent: " + std::to_string(_client.responseCode));
 		_client.responseSent = true;
+		_client.lastActivity = time(nullptr);
 	}
 }
 


### PR DESCRIPTION
Adds client connectionStatus PROCESSING and prevents timing out clients when the server is processing their requests.

One issue that this causes, and still needs to be fixed, is that if a client  abruptly disconnects and leaves its socket in a limbo, where only POLLIN activates, the connection will not be cleared on server side. This only occurs after siege and appears differently when siege is exited with ctrl + c vs stops after a set time or number of repetitions. Added to issues, will address this next.

Closes #174 