### PR TITLE
Fix/detect half closed connections

### DIFF
--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -33,17 +33,13 @@ void RequestHandler::resetHandler() {
 void RequestHandler::handleRequest() {
 	if (!_request)
 		_request = std::make_unique<HttpRequest>();
-	if (!_readReady)
-		readRequest();
-	else if (_multipart && ++_partIndex < _parts.size()) {
+	readRequest();
+	if (_multipart && ++_partIndex < _parts.size()) {
 		_client.resourcePath = ServerConfigData::getRoot(*_client.serverConfig, _request->uriPath) + _request->uriPath + "/" + _parts[_partIndex].filename;
 		_client.resourceOutString = _parts[_partIndex].content;
 		FileHandler::openForWrite( _client.resourceWriteFd, _client.resourcePath);
 	}
-	else if (_client.cgiRequested && _client.cgiStatus != CGI_RESPONSE_READY) {
-		return;
-	}
-	else
+	else if (_multipart || (_client.cgiRequested && _client.cgiStatus == CGI_RESPONSE_READY))
 		_client.requestReady = true;
 }
 

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -162,7 +162,13 @@ void ServerHandler::closeConnection(size_t& i)
 	while (it != _resourceFds.end() && !_resourceFds.empty())
 	{
 		if (it->second == &client)
-			removeResourceFd(it->first);
+		{
+			if (it->first != -1) {
+				_fdsToDrop.push_back(it->first);
+				close(it->first);
+			}
+			it = _resourceFds.erase(it);
+		}
 		else
 			++it;
 	}


### PR DESCRIPTION
Gets the half-connected clients out of the limo!

Problem was not recving on pollin events to catch disconnect status and then in closeConnection removing iterated elements during the iteration.

Closes #176 