### PR TITLE
Makes readRequest public and uses that to read on client pollIn

### DIFF
--- a/includes/RequestHandler.hpp
+++ b/includes/RequestHandler.hpp
@@ -35,7 +35,6 @@ class RequestHandler
 		size_t _totalReceivedLength;
 		size_t _partIndex;
 		std::vector <MultipartFormData> _parts;
-		void readRequest();
 		void processRequest();
 		void processGet();
 		void processPost();
@@ -57,6 +56,7 @@ class RequestHandler
 		~RequestHandler();
 		void resetHandler();
 		void handleRequest();
+		void readRequest();
 
 		const HttpRequest& getRequest() const;
 		const std::string& getMethod() const;

--- a/sources/RequestHandler.cpp
+++ b/sources/RequestHandler.cpp
@@ -31,19 +31,18 @@ void RequestHandler::resetHandler() {
 }
 
 void RequestHandler::handleRequest() {
-	if (!_request)
-		_request = std::make_unique<HttpRequest>();
-	readRequest();
 	if (_multipart && ++_partIndex < _parts.size()) {
 		_client.resourcePath = ServerConfigData::getRoot(*_client.serverConfig, _request->uriPath) + _request->uriPath + "/" + _parts[_partIndex].filename;
 		_client.resourceOutString = _parts[_partIndex].content;
 		FileHandler::openForWrite( _client.resourceWriteFd, _client.resourcePath);
 	}
-	else if (_multipart || (_client.cgiRequested && _client.cgiStatus == CGI_RESPONSE_READY))
+	else if (_multipart || (_client.cgiRequested && !(_client.cgiStatus != CGI_RESPONSE_READY)))
 		_client.requestReady = true;
 }
 
 void RequestHandler::readRequest() {
+	if (!_request)
+		_request = std::make_unique<HttpRequest>();
 	ssize_t receivedBytes;
 	char buf[BUFFER_SIZE] = {};
 

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -123,7 +123,7 @@ void ServerHandler::checkClients()
 			Client& client = *it->second.get();
 			if (client.cgiRequested && !client.responseSent && client.cgiStatus != CGI_COMPLETE)
 				_CGIHandler.checkProcess(client);
-			else if (client.connectionState == CLOSE)
+			if (client.connectionState == CLOSE)
 			{
 				Logger::log(Logger::OK, "Client " + std::to_string(client.fd) + " connection disconnected by client");
 				closeConnection(i);
@@ -311,7 +311,7 @@ void	ServerHandler::pollLoop()
 						else if (_clients.find(_pollFds[i].fd) != _clients.end()) // Clients in
 						{
 							Client& client = *_clients[_pollFds[i].fd].get();
-							client.requestHandler->handleRequest();
+							client.requestHandler->readRequest();
 							if (client.cgiRequested)
 								_CGIHandler.handleCGI(client);
 							if (client.responseCode == STATUS_OK)


### PR DESCRIPTION
Going through handleRequest caused issues, as that was also called at the end of writeToFd to process multipart and cgi calls.