### PR TITLE
Fixes CGI handling in case of signal termination

### DIFF
--- a/includes/CGIHandler.hpp
+++ b/includes/CGIHandler.hpp
@@ -47,7 +47,7 @@ private:
 	void						setupCGI(Client& client);
 	void						runCGIScript(Client& client);
 	bool						readyForExecve(const Client& client);
-	void						setPipesToNonBlock(int* pipe);
+	void						setPipesToNonBlock(std::vector<int> pipeFds);
 	void						closeAllOpenFds();
 	void						cleanupPid(pid_t pid);
 	bool						cgiTimeout(Client& client);
@@ -61,4 +61,5 @@ private:
 	void	cleanupCGI(Client& client);
 	void	killCGIProcess(Client& client);
 	void	checkCGIStatus(Client& client);
+	void	signalShutdown();
 };

--- a/sources/ServerHandler.cpp
+++ b/sources/ServerHandler.cpp
@@ -336,6 +336,7 @@ void	ServerHandler::pollLoop()
 			continue;
 		}
 	}
+	_CGIHandler.signalShutdown();
 	for (pollfd p : _pollFds)
 		close(p.fd);
 	for (pollfd p : _newPollFds)


### PR DESCRIPTION
Handles closing down all unclosed fds from main process, as well as in child process after a sigterm signal shuts down the servers

also makes setting the pipes to nonblocking mode a bit cleaner, functionality stays the same